### PR TITLE
validation: bundle CRDs are compared by definition key instead of name

### DIFF
--- a/pkg/validation/internal/bundle_test.go
+++ b/pkg/validation/internal/bundle_test.go
@@ -26,16 +26,16 @@ func TestValidateBundle(t *testing.T) {
 			hasError:    false,
 		},
 		{
-			description: "registryv1 bundle/valid bundle",
+			description: "registryv1 bundle/invalid bundle",
 			directory:   "./testdata/invalid_bundle",
 			hasError:    true,
-			errString:   `owned CRD "etcdclusters.etcd.database.coreos.com" not found in bundle`,
+			errString:   "owned CRD etcdclusters.etcd.database.coreos.com/v1beta2 not found in bundle",
 		},
 		{
-			description: "registryv1 bundle/valid bundle",
+			description: "registryv1 bundle/invalid bundle 2",
 			directory:   "./testdata/invalid_bundle_2",
 			hasError:    true,
-			errString:   `owned CRD "etcdclusters.etcd.database.coreos.com" is present in bundle "test" but not defined in CSV`,
+			errString:   `CRD etcdclusters.etcd.database.coreos.com/v1beta2 is present in bundle "test" but not defined in CSV`,
 		},
 	}
 
@@ -64,7 +64,7 @@ func TestValidateBundle(t *testing.T) {
 		results := BundleValidator.Validate(bundle)
 
 		if len(results) > 0 {
-			require.Equal(t, results[0].HasError(), tt.hasError)
+			require.Equal(t, tt.hasError, results[0].HasError(), "%s: %s", tt.description, results[0])
 			if results[0].HasError() {
 				require.Contains(t, results[0].Errors[0].Error(), tt.errString)
 			}

--- a/pkg/validation/internal/csv.go
+++ b/pkg/validation/internal/csv.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"reflect"
@@ -185,4 +186,16 @@ func validateInstallModes(csv *v1alpha1.ClusterServiceVersion) (errs []errors.Er
 		errs = append(errs, errors.ErrInvalidCSV("none of InstallModeTypes are supported", csv.GetName()))
 	}
 	return errs
+}
+
+func bundleCSVToCSV(bcsv *registry.ClusterServiceVersion) (*v1alpha1.ClusterServiceVersion, errors.Error) {
+	spec := v1alpha1.ClusterServiceVersionSpec{}
+	if err := json.Unmarshal(bcsv.Spec, &spec); err != nil {
+		return nil, errors.ErrInvalidParse(fmt.Sprintf("converting bundle CSV %q", bcsv.GetName()), err)
+	}
+	return &v1alpha1.ClusterServiceVersion{
+		TypeMeta:   bcsv.TypeMeta,
+		ObjectMeta: bcsv.ObjectMeta,
+		Spec:       spec,
+	}, errors.Error{}
 }


### PR DESCRIPTION
CRDs should not be compared by name because each CSV `customresourcedefinition` element is not unique by name only, i.e. multiple versions of the same CRD are allowed.

Also fixed a test comparison (wrong argument order).

/kind bug

/cc @dinhxuanvu @kevinrizza 