### PR TITLE
pkg/manifests: use yaml decoder to avoid conversion errors

### DIFF
--- a/pkg/manifests/packagemanifestloader.go
+++ b/pkg/manifests/packagemanifestloader.go
@@ -61,6 +61,7 @@ func (p *packageManifestLoader) LoadPackagesWalkFunc(path string, f os.FileInfo,
 	if err != nil {
 		return fmt.Errorf("unable to load package from file %s: %s", path, err)
 	}
+	defer fileReader.Close()
 
 	decoder := yaml.NewYAMLOrJSONDecoder(fileReader, 30)
 	manifest := PackageManifest{}
@@ -103,6 +104,7 @@ func (p *packageManifestLoader) LoadBundleWalkFunc(path string, f os.FileInfo, e
 	if err != nil {
 		return fmt.Errorf("unable to load file %s: %s", path, err)
 	}
+	defer fileReader.Close()
 
 	decoder := yaml.NewYAMLOrJSONDecoder(fileReader, 30)
 	csv := unstructured.Unstructured{}


### PR DESCRIPTION
See https://github.com/operator-framework/operator-registry/pull/334.

/cc @dinhxuanvu @kevinrizza @gallettilance 

/kind bug