### PR TITLE
fix(crd): Fix CRD validation falsely error on unused CRD versions

### DIFF
--- a/pkg/validation/internal/bundle_test.go
+++ b/pkg/validation/internal/bundle_test.go
@@ -21,6 +21,11 @@ func TestValidateBundle(t *testing.T) {
 			hasError:    false,
 		},
 		{
+			description: "registryv1 valid bundle with multiple versions in CRD",
+			directory:   "./testdata/valid_bundle_2",
+			hasError:    false,
+		},
+		{
 			description: "registryv1 invalid bundle without CRD etcdclusters v1beta2 in bundle",
 			directory:   "./testdata/invalid_bundle",
 			hasError:    true,

--- a/pkg/validation/internal/testdata/valid_bundle_2/test-operator.clusterserviceversion.yaml
+++ b/pkg/validation/internal/testdata/valid_bundle_2/test-operator.clusterserviceversion.yaml
@@ -1,0 +1,41 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    capabilities: Basic Install
+  name: test-operator.v0.0.1
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Test is the Schema for the tests API
+      kind: Test
+      name: tests.test.example.com
+      version: v1alpha1
+    - description: TestTwo is the Schema for the tests API
+      kind: TestTwo
+      name: TestTwos.test.example.com
+      version: v1beta1
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - test-operator
+  links:
+  - name: Test Operator
+    url: https://test-operator.domain
+  maintainers:
+  - email: your@email.com
+    name: Maintainer Name
+  maturity: alpha
+  provider:
+    name: Provider Name
+    url: https://your.domain
+  version: 0.0.1

--- a/pkg/validation/internal/testdata/valid_bundle_2/test.example.com_tests_v1_crd.yaml
+++ b/pkg/validation/internal/testdata/valid_bundle_2/test.example.com_tests_v1_crd.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: tests.test.example.com
+spec:
+  group: test.example.com
+  names:
+    kind: Test
+    listKind: TestList
+    plural: tests
+    singular: test
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false

--- a/pkg/validation/internal/testdata/valid_bundle_2/test.example.com_testtwos_v1beta1_crd.yaml
+++ b/pkg/validation/internal/testdata/valid_bundle_2/test.example.com_testtwos_v1beta1_crd.yaml
@@ -1,0 +1,20 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: testtwos.test.example.com
+spec:
+  group: test.example.com
+  names:
+    kind: TestTwo
+    listKind: TestTwoList
+    plural: testtwos
+    singular: testtwo
+  scope: Namespaced
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+  - name: v1alpha1
+    served: true
+    storage: false


### PR DESCRIPTION
CRD can have multiple versions and CSV can only reference one version.
CRD validation falsely errors out when there are unused versions in
provided CRDs.

Signed-off-by: Vu Dinh <vdinh@redhat.com>