### PR TITLE
Approval: Clarify possible values

### DIFF
--- a/crds/operators.coreos.com_installplans.yaml
+++ b/crds/operators.coreos.com_installplans.yaml
@@ -62,6 +62,7 @@ spec:
             properties:
               approval:
                 description: Approval is the user approval policy for an InstallPlan.
+                  It must be one of "Automatic" or "Manual".
                 type: string
               approved:
                 type: boolean

--- a/crds/operators.coreos.com_subscriptions.yaml
+++ b/crds/operators.coreos.com_subscriptions.yaml
@@ -1634,6 +1634,7 @@ spec:
                               type: string
               installPlanApproval:
                 description: Approval is the user approval policy for an InstallPlan.
+                  It must be one of "Automatic" or "Manual".
                 type: string
               name:
                 type: string

--- a/pkg/operators/v1alpha1/installplan_types.go
+++ b/pkg/operators/v1alpha1/installplan_types.go
@@ -14,6 +14,7 @@ const (
 )
 
 // Approval is the user approval policy for an InstallPlan.
+// It must be one of "Automatic" or "Manual".
 type Approval string
 
 const (


### PR DESCRIPTION
Currently this field does not seem to get defaulted (should it?) and the docs are pretty useless because the name is self-explanatory for the what, but the how is not documented:

```
$ k explain subscription.spec.installPlanApproval
KIND:     Subscription
VERSION:  operators.coreos.com/v1alpha1

FIELD:    installPlanApproval <string>

DESCRIPTION:
     Approval is the user approval policy for an InstallPlan.
```