### PR TITLE
fix: find bundle objects in verify command

### DIFF
--- a/pkg/manifests/bundle.go
+++ b/pkg/manifests/bundle.go
@@ -30,6 +30,7 @@ func (b *Bundle) ObjectsToValidate() []interface{} {
 		objs = append(objs, crd)
 	}
 	objs = append(objs, b.CSV)
+	objs = append(objs, b.Objects)
 	objs = append(objs, b)
 
 	return objs

--- a/pkg/validation/internal/object.go
+++ b/pkg/validation/internal/object.go
@@ -37,17 +37,20 @@ var defaultSCCs = map[string]struct{}{
 
 func validateObjects(objs ...interface{}) (results []errors.ManifestResult) {
 	for _, obj := range objs {
-		switch u := obj.(type) {
-		case *unstructured.Unstructured:
-			switch u.GroupVersionKind().Kind {
-			case PodDisruptionBudgetKind:
-				results = append(results, validatePDB(u))
-			case PriorityClassKind:
-				results = append(results, validatePriorityClass(u))
-			case RoleKind:
-				results = append(results, validateRBAC(u))
-			case ClusterRoleKind:
-				results = append(results, validateRBAC(u))
+		switch obj.(type) {
+		case []*unstructured.Unstructured:
+			objects := obj.([]*unstructured.Unstructured)
+			for _, u := range objects {
+				switch u.GroupVersionKind().Kind {
+				case PodDisruptionBudgetKind:
+					results = append(results, validatePDB(u))
+				case PriorityClassKind:
+					results = append(results, validatePriorityClass(u))
+				case RoleKind:
+					results = append(results, validateRBAC(u))
+				case ClusterRoleKind:
+					results = append(results, validateRBAC(u))
+				}
 			}
 		}
 	}

--- a/pkg/validation/internal/object_test.go
+++ b/pkg/validation/internal/object_test.go
@@ -75,7 +75,8 @@ func TestValidateObject(t *testing.T) {
 			t.Fatalf("unmarshalling object at path %s: %v", tt.path, err)
 		}
 
-		results := ObjectValidator.Validate(&u)
+		obj := []*unstructured.Unstructured{&u}
+		results := ObjectValidator.Validate(obj)
 
 		// check errors
 		if len(results[0].Errors) > 0 && tt.error == false {


### PR DESCRIPTION
The objects provided to the validator is in  an `[]*unstructured.Unstructured` so it needs to be asserted first before validating. 