### PR TITLE
fix: pass in bundle objects

### DIFF
--- a/pkg/manifests/bundle.go
+++ b/pkg/manifests/bundle.go
@@ -30,6 +30,10 @@ func (b *Bundle) ObjectsToValidate() []interface{} {
 		objs = append(objs, crd)
 	}
 	objs = append(objs, b.CSV)
+
+	for _, o := range b.Objects {
+		objs = append(objs, o)
+	}
 	objs = append(objs, b)
 
 	return objs


### PR DESCRIPTION
Passes in bundle objects correctly so the `operator-verify`  command works