### PR TITLE
Update github action setup-go to version 1.1.3     

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.13
-      uses: actions/setup-go@v1.1.2
+      uses: actions/setup-go@v1.1.3
       with:
         go-version: 1.13
       id: go


### PR DESCRIPTION
Fixes a security vulnerability that allowed environment variables and path injection in workflows that log untrusted data to STDOUT, possibly resulting in environment variables being introducd or modified without the intention of the workflow operator.
    
Ref: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
