### PR TITLE
(fix) make operatorhub validation consistent with courier

### DIFF
--- a/pkg/validation/errors/error.go
+++ b/pkg/validation/errors/error.go
@@ -243,3 +243,7 @@ func invalidObject(lvl Level, detail string, value interface{}) Error {
 func WarnInvalidObject(detail string, value interface{}) Error {
 	return failedValidation(LevelWarn, detail, value)
 }
+
+func WarnMissingIcon(detail string) Error {
+	return failedValidation(LevelWarn, detail, "")
+}

--- a/pkg/validation/internal/operatorhub.go
+++ b/pkg/validation/internal/operatorhub.go
@@ -146,7 +146,7 @@ func validateHubCSVSpec(csv v1alpha1.ClusterServiceVersion) []error {
 			}
 		}
 	} else {
-		errs = append(errs, fmt.Errorf("csv.Spec.Icon not specified"))
+		errs = append(errs, errors.WarnMissingIcon("csv.Spec.Icon not specified"))
 	}
 
 	if categories, ok := csv.ObjectMeta.Annotations["categories"]; ok {
@@ -161,14 +161,14 @@ func validateHubCSVSpec(csv v1alpha1.ClusterServiceVersion) []error {
 				return errs
 			}
 			for _, category := range categorySlice {
-				if _, ok := customCategories[category]; !ok {
+				if _, ok := customCategories[strings.TrimSpace(category)]; !ok {
 					errs = append(errs, fmt.Errorf("csv.Metadata.Annotations.Categories %s is not a valid custom category", category))
 				}
 			}
 		} else {
 			// use default categories
 			for _, category := range categorySlice {
-				if _, ok := validCategories[category]; !ok {
+				if _, ok := validCategories[strings.TrimSpace(category)]; !ok {
 					errs = append(errs, fmt.Errorf("csv.Metadata.Annotations.Categories %s is not a valid category", category))
 				}
 			}

--- a/pkg/validation/internal/testdata/valid_bundle/etcdoperator.v0.9.4.clusterserviceversion.yaml
+++ b/pkg/validation/internal/testdata/valid_bundle/etcdoperator.v0.9.4.clusterserviceversion.yaml
@@ -16,7 +16,7 @@ metadata:
       ],\n      \"storageType\":\"S3\",\n      \"s3\": {\n        \"path\": \"<full-s3-path>\"\
       ,\n        \"awsSecret\": \"<aws-secret>\"\n      }\n    }\n  }\n]\n"
     capabilities: Full Lifecycle
-    categories: Database
+    categories: Database, Big Data
     containerImage: quay.io/coreos/etcd-operator@sha256:66a37fd61a06a43969854ee6d3e21087a98b93838e284a6086b13917f96b0d9b
     createdAt: 2019-02-28 01:03:00
     description: Create and maintain highly-available etcd clusters on Kubernetes


### PR DESCRIPTION
The missing csv spec.icon field is now a warning (was a failure)
The csv metadata.annotations.categories field tolerates extra spaces at the start and end of the category