### PR TITLE
Add OperatorUpgradeable condition type to OperatorCondition api

### DIFF
--- a/pkg/operators/v1/operatorcondition_types.go
+++ b/pkg/operators/v1/operatorcondition_types.go
@@ -4,6 +4,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// OperatorUpgradeable indicates that the operator is upgradeable
+	OperatorUpgradeable ConditionType = "OperatorUpgradeable"
+)
+
 // OperatorConditionSpec allows a cluster admin to convey information about the state of an operator to OLM, potentially overriding state reported by the operator.
 type OperatorConditionSpec struct {
 	ServiceAccounts []string           `json:"serviceAccounts,omitempty"`


### PR DESCRIPTION
This condition type is used to signify that the operator is
upgradeable.

Signed-off-by: Vu Dinh <vdinh@redhat.com>