### PR TITLE
fix: remove extra test output from unit tests

### DIFF
--- a/pkg/validation/internal/object_test.go
+++ b/pkg/validation/internal/object_test.go
@@ -64,8 +64,6 @@ func TestValidateObject(t *testing.T) {
 	}
 
 	for _, tt := range table {
-		t.Log(tt.description)
-
 		u := unstructured.Unstructured{}
 		o, err := ioutil.ReadFile(tt.path)
 		if err != nil {

--- a/pkg/validation/internal/operatorhub_test.go
+++ b/pkg/validation/internal/operatorhub_test.go
@@ -83,7 +83,6 @@ func TestCustomCategories(t *testing.T) {
 	}
 
 	for _, tt := range table {
-		t.Logf("%s", tt.description)
 		if tt.custom {
 			os.Setenv("OPERATOR_BUNDLE_CATEGORIES", "./testdata/categories.json")
 		} else {


### PR DESCRIPTION
Extra test output writes to stderr in GH actions and causes the unit test output to produce erroneous error messages. 
Removing these test logs (which just log the name of the test) removes errors from the unit test output:
```
--- PASS: TestValidateObject (0.00s)
Error:     object_test.go:67: valid PDB
Error:     object_test.go:67: invalid PDB - minAvailable set to 100%
Error:     object_test.go:67: invalid PDB - maxUnavailable set to 0
Error:     object_test.go:67: valid priorityclass
Error:     object_test.go:67: invalid priorityclass - global default set to true
Error:     object_test.go:67: valid pdb role
Error:     object_test.go:67: invalid role - modify pdb
Error:     object_test.go:67: valid scc role
Error:     object_test.go:67: invalid scc role - modify default scc
```