### PR TITLE
Change OperatorUpgradeable type to string and add utils func

### DIFF
--- a/pkg/operators/v1/operatorcondition_types.go
+++ b/pkg/operators/v1/operatorcondition_types.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	// OperatorUpgradeable indicates that the operator is upgradeable
-	OperatorUpgradeable ConditionType = "OperatorUpgradeable"
+	OperatorUpgradeable string = "OperatorUpgradeable"
 )
 
 // OperatorConditionSpec allows a cluster admin to convey information about the state of an operator to OLM, potentially overriding state reported by the operator.

--- a/pkg/operators/v1alpha1/clusterserviceversion_types.go
+++ b/pkg/operators/v1alpha1/clusterserviceversion_types.go
@@ -379,6 +379,7 @@ const (
 	CSVReasonCannotModifyStaticOperatorGroupProvidedAPIs ConditionReason = "CannotModifyStaticOperatorGroupProvidedAPIs"
 	CSVReasonDetectedClusterChange                       ConditionReason = "DetectedClusterChange"
 	CSVReasonInvalidWebhookDescription                   ConditionReason = "InvalidWebhookDescription"
+	CSVReasonOperatorConditionNotUpgradeable             ConditionReason = "OperatorConditionNotUpgradeable"
 )
 
 // HasCaResources returns true if the CSV has owned APIServices or Webhooks.


### PR DESCRIPTION
Use string as OperatorUpgradeable type instead of intermediate
type ConditionType.

Add utils func FindConditionType to look up Condition type.

Signed-off-by: Vu Dinh <vdinh@redhat.com>