### PR TITLE
Update go version to 1.15

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -11,10 +11,10 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.13
+    - name: Set up Go 1.15
       uses: actions/setup-go@v1.1.3
       with:
-        go-version: 1.13
+        go-version: 1.15
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2.0.0

--- a/cmd/operator-verify/manifests/cmd.go
+++ b/cmd/operator-verify/manifests/cmd.go
@@ -43,7 +43,7 @@ func manifestsFunc(cmd *cobra.Command, args []string) {
 
 	bundleObjectValidate, err := cmd.Flags().GetBool("object_validate")
 	if err != nil {
-		log.Fatalf("Unable to parse object_validate parameter: %w", err)
+		log.Fatalf("Unable to parse object_validate parameter: %v", err)
 	}
 
 	validators := validation.DefaultBundleValidators

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/operator-framework/api
 
-go 1.13
+go 1.15
 
 require (
 	github.com/blang/semver v3.5.0+incompatible

--- a/pkg/validation/internal/operatorhub_test.go
+++ b/pkg/validation/internal/operatorhub_test.go
@@ -30,7 +30,7 @@ func TestValidateBundleOperatorHub(t *testing.T) {
 				`Error: Value : (etcdoperator.v0.9.4) csv.Spec.Maintainers elements should contain both name and email`,
 				`Error: Value : (etcdoperator.v0.9.4) csv.Spec.Maintainers email invalidemail is invalid: mail: missing '@' or angle-addr`,
 				`Error: Value : (etcdoperator.v0.9.4) csv.Spec.Links elements should contain both name and url`,
-				`Error: Value : (etcdoperator.v0.9.4) csv.Spec.Links url https//coreos.com/operators/etcd/docs/latest/ is invalid: parse https//coreos.com/operators/etcd/docs/latest/: invalid URI for request`,
+				`Error: Value : (etcdoperator.v0.9.4) csv.Spec.Links url https//coreos.com/operators/etcd/docs/latest/ is invalid: parse "https//coreos.com/operators/etcd/docs/latest/": invalid URI for request`,
 				`Error: Value : (etcdoperator.v0.9.4) csv.Metadata.Annotations.Capabilities Installs and stuff is not a valid capabilities level`,
 				`Error: Value : (etcdoperator.v0.9.4) csv.Spec.Icon should only have one element`,
 				`Error: Value : (etcdoperator.v0.9.4) csv.Metadata.Annotations.Categories Magic is not a valid category`,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -7,6 +7,7 @@ github.com/asaskevich/govalidator
 # github.com/beorn7/perks v1.0.1
 github.com/beorn7/perks/quantile
 # github.com/blang/semver v3.5.0+incompatible
+## explicit
 github.com/blang/semver
 # github.com/cespare/xxhash/v2 v2.1.1
 github.com/cespare/xxhash/v2
@@ -15,8 +16,10 @@ github.com/davecgh/go-spew/spew
 # github.com/fatih/color v1.7.0
 github.com/fatih/color
 # github.com/ghodss/yaml v1.0.0
+## explicit
 github.com/ghodss/yaml
 # github.com/go-bindata/go-bindata/v3 v3.1.3
+## explicit
 github.com/go-bindata/go-bindata/v3
 # github.com/go-logr/logr v0.2.0
 github.com/go-logr/logr
@@ -66,6 +69,7 @@ github.com/googleapis/gnostic/openapiv2
 github.com/hashicorp/golang-lru
 github.com/hashicorp/golang-lru/simplelru
 # github.com/imdario/mergo v0.3.8
+## explicit
 github.com/imdario/mergo
 # github.com/inconshreveable/mousetrap v1.0.0
 github.com/inconshreveable/mousetrap
@@ -89,6 +93,7 @@ github.com/matttproud/golang_protobuf_extensions/pbutil
 # github.com/mikefarah/yaml/v2 v2.4.0
 github.com/mikefarah/yaml/v2
 # github.com/mikefarah/yq/v2 v2.4.1
+## explicit
 github.com/mikefarah/yq/v2
 # github.com/mitchellh/mapstructure v1.1.2
 github.com/mitchellh/mapstructure
@@ -96,6 +101,10 @@ github.com/mitchellh/mapstructure
 github.com/modern-go/concurrent
 # github.com/modern-go/reflect2 v1.0.1
 github.com/modern-go/reflect2
+# github.com/onsi/ginkgo v1.12.0
+## explicit
+# github.com/onsi/gomega v1.9.0
+## explicit
 # github.com/pkg/errors v0.9.1
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
@@ -115,12 +124,15 @@ github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
 # github.com/sirupsen/logrus v1.6.0
+## explicit
 github.com/sirupsen/logrus
 # github.com/spf13/cobra v1.0.0
+## explicit
 github.com/spf13/cobra
 # github.com/spf13/pflag v1.0.5
 github.com/spf13/pflag
 # github.com/stretchr/testify v1.5.1
+## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # go.mongodb.org/mongo-driver v1.1.2
@@ -266,6 +278,7 @@ gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.0-20190905181640-827449938966
 gopkg.in/yaml.v3
 # k8s.io/api v0.19.3
+## explicit
 k8s.io/api/admissionregistration/v1
 k8s.io/api/admissionregistration/v1beta1
 k8s.io/api/apps/v1
@@ -308,6 +321,7 @@ k8s.io/api/storage/v1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
 # k8s.io/apiextensions-apiserver v0.19.3
+## explicit
 k8s.io/apiextensions-apiserver/pkg/apihelpers
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install
@@ -320,6 +334,7 @@ k8s.io/apiextensions-apiserver/pkg/apiserver/schema/objectmeta
 k8s.io/apiextensions-apiserver/pkg/apiserver/schema/pruning
 k8s.io/apiextensions-apiserver/pkg/apiserver/validation
 # k8s.io/apimachinery v0.19.3
+## explicit
 k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/api/meta
@@ -372,6 +387,7 @@ k8s.io/apiserver/pkg/server/egressselector
 k8s.io/apiserver/pkg/server/egressselector/metrics
 k8s.io/apiserver/pkg/util/webhook
 # k8s.io/client-go v0.19.3
+## explicit
 k8s.io/client-go/kubernetes/scheme
 k8s.io/client-go/pkg/apis/clientauthentication
 k8s.io/client-go/pkg/apis/clientauthentication/v1alpha1
@@ -413,8 +429,10 @@ k8s.io/utils/trace
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client
 # sigs.k8s.io/controller-runtime v0.6.0
+## explicit
 sigs.k8s.io/controller-runtime/pkg/scheme
 # sigs.k8s.io/controller-tools v0.3.0
+## explicit
 sigs.k8s.io/controller-tools/cmd/controller-gen
 sigs.k8s.io/controller-tools/pkg/crd
 sigs.k8s.io/controller-tools/pkg/crd/markers


### PR DESCRIPTION
This PR updates the go version to 1.15. Changes made in:
* go.mod
* .github/workflows/go.yaml