### PR TITLE
Add optional go-apidiff test to CI

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -11,12 +11,29 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.15
-      uses: actions/setup-go@v1.1.3
+    - name: Set up Go
+      uses: actions/setup-go@v2
       with:
         go-version: 1.15
       id: go
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2.0.0
+      uses: actions/checkout@v2
     - name: unit-test
       run: go test -mod=vendor -v ./...
+
+  go-apidiff:
+    name: go-apidiff
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.15
+      id: go
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Run go-apidiff
+      uses: joelanford/go-apidiff@master


### PR DESCRIPTION
I wrote [`go-apidiff`](https://github.com/joelanford/go-apidiff) to help maintainers of `kubernetes-sigs/controller-runtime` easily identify PRs that break Go APIs. It's also being used in `kubernetes-sigs/cluster-api*` repos.

Today I finally got around to making a GitHub action out of it. I figured it might help in some of the operator-framework repos that are used as libraries.

It will compare the PR head with the target branch, report any API changes, and fail if any of them are breaking changes. Other projects using this make this test optional so that it is a simple signal to maintainers about whether changes are API-compatible.