### PR TITLE
feat: update the channel namming conv

### DIFF
--- a/pkg/validation/internal/operatorhub.go
+++ b/pkg/validation/internal/operatorhub.go
@@ -130,13 +130,13 @@ func validateBundleOperatorHub(bundle *manifests.Bundle, k8sVersion string) erro
 // authors knows if their operator bundles are or not respecting the Naming Convention Rules.
 // However, the operator authors still able to choose the names as please them.
 func validateHubChannels(channels []string) error {
-	const preview = "preview"
+	const candidate = "candidate"
 	const stable = "stable"
 	const fast = "fast"
 
 	var channelsNotFollowingConventional []string
 	for _, channel := range channels {
-		if !strings.HasPrefix(channel, preview) &&
+		if !strings.HasPrefix(channel, candidate) &&
 			!strings.HasPrefix(channel, stable) &&
 			!strings.HasPrefix(channel, fast) {
 			channelsNotFollowingConventional = append(channelsNotFollowingConventional, channel)

--- a/pkg/validation/internal/operatorhub_test.go
+++ b/pkg/validation/internal/operatorhub_test.go
@@ -474,7 +474,7 @@ func TestValidateHubChannels(t *testing.T) {
 		{
 			name: "should not return warning when the channel names following the convention",
 			args: args{
-				channels: []string{"fast", "preview"},
+				channels: []string{"fast", "candidate"},
 			},
 			wantWarn: false,
 		},


### PR DESCRIPTION
**Description**
Replace `preview` with `candidate` for channel naming check. 

**Motivation**
That was checked that the most appropriated convention name would be candidate instead of preview. See: https://github.com/operator-framework/olm-docs/pull/162
