### PR TITLE
cmd/operator-verify: Update the validating manifests command

### DIFF
--- a/cmd/operator-verify/manifests/cmd.go
+++ b/cmd/operator-verify/manifests/cmd.go
@@ -11,13 +11,17 @@ import (
 
 func NewCmd() *cobra.Command {
 	rootCmd := &cobra.Command{
-		Use:   "manifests",
-		Short: "Validates all manifests in a directory",
-		Long: `'operator-verify manifests' validates a bundle in the supplied directory
-and prints errors and warnings corresponding to each manifest found to be
-invalid. Manifests are only validated if a validator for that manifest
-type/kind, ex. CustomResourceDefinition, is implemented in the Operator
-validation library.`,
+		Use:   "manifests <manifestDir>",
+		Short: "Validate all manifests in a directory",
+		Args:  cobra.ExactArgs(1),
+		Long: `Validate the contents of a bundle in the supplied <manifestDir> directory.
+
+For each manifest in the <manifestDir> directory, this command will print any errors
+or warnings produced during the validation process.
+
+Note: certain manifests may be ignored during the validation process if a validator
+for that type/Kind has not been implemented yet in the Operator validation library.
+`,
 		Run: manifestsFunc,
 	}
 
@@ -38,7 +42,7 @@ func manifestsFunc(cmd *cobra.Command, args []string) {
 
 	operatorHubValidate, err := cmd.Flags().GetBool("operatorhub_validate")
 	if err != nil {
-		log.Fatalf("Unable to parse operatorhub_validate parameter")
+		log.Fatalf("Unable to parse operatorhub_validate parameter: %v", err)
 	}
 
 	bundleObjectValidate, err := cmd.Flags().GetBool("object_validate")


### PR DESCRIPTION
Update the operator-verify command package:

- Update the `... manifest validate` command and ensure only a single
  argument is being passed to the executable. This will fix a panic
  being produced when attempting to access the first element on the
  arguments array.
- Update an error message that uses a format specifier but no variable
  was being passed.
- Update the use/short/long description so it's clearer as to what the
  expected input should be.

Update the .gitignore:

- Ensure the root bin/ directory is being excluded, which typically houses binaries generated from local go build operations.