### PR TITLE
 (feat): community validator: cleanups, changes and improvements

### DIFF
--- a/pkg/validation/internal/community.go
+++ b/pkg/validation/internal/community.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"encoding/json"
+	golangerrors "errors"
 	"fmt"
 	"github.com/blang/semver"
 	"io/ioutil"
@@ -13,33 +14,58 @@ import (
 	interfaces "github.com/operator-framework/api/pkg/validation/interfaces"
 )
 
-// IndexImagePathKey defines the key which can be used by its consumers
-// to inform where their index image path is to be checked
-const IndexImagePathKey = "index-path"
+// FilePathKey defines the key which can be used by its consumers
+// to inform where their index bundle image or annotations path to be checked
+const FilePathKey = "file"
 
-// ocpLabelindex defines the OCP label which allow configure the OCP versions
+// RangeKey defines the key which can be used by its consumers
+// to inform where their label range value only to be checked
+const RangeKey = "range"
+
+// ocpLabel defines the OCP label which allow configure the OCP versions
 // where the bundle will be distributed
-const ocpLabelindex = "com.redhat.openshift.versions"
+const ocpLabel = "com.redhat.openshift.versions"
+
+// deprecateOcpLabelMsg1_22 returns the specific ocp label message which is valid only for 1.22/OCP 4.9
+const deprecateOcpLabelMsg1_22 = "this bundle is using APIs which were deprecated and " +
+	"removed in v1.22. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22. " +
+	"Migrate the APIs " +
+	"for %s or provide compatible version(s) via the labels. (e.g. LABEL %s='4.6-4.8')"
 
 // OCP version where the apis v1beta1 is no longer supported
 const ocpVerV1beta1Unsupported = "4.9"
 
+// Ensure that has the OCPMaxAnnotation
+const olmproperties = "olm.properties"
+const olmmaxOcpVersion = "olm.maxOpenShiftVersion"
+
+// TODO: Decouple this validator to a vendor-specific project like
+// https://issues.redhat.com/browse/OSDK-1894
+
 // CommunityOperatorValidator validates the bundle manifests against the required criteria to publish
-// the projects on the community operators
+// the projects on the ocp community operators (https://github.com/redhat-openshift-ecosystem/community-operators-prod)
 //
-// Note that this validator allows to receive a List of optional values as key=values. Currently, only the
-// `index-path` key is allowed. If informed, it will check the labels on the image index according to its criteria.
-var CommunityOperatorValidator interfaces.Validator = interfaces.ValidatorFunc(communityValidator)
+// Note that this validator allows to receive a List of optional values as key=values:
+// - file: expected the index bundle image(bundle.Dockerfile) or annotations path
+// - range: expected an string value with the syntax described in https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/bundle-directory/managing-openshift-versions
+//
+// Be aware that this validator is in alpha stage and can be changed. Also, the intention here is to decouple
+// this validator and move it out of this project.
+var CommunityOperatorValidator interfaces.Validator = interfaces.ValidatorFunc(alphaCommunityValidator)
 
-func communityValidator(objs ...interface{}) (results []errors.ManifestResult) {
+func alphaCommunityValidator(objs ...interface{}) (results []errors.ManifestResult) {
 
-	// Obtain the k8s version if informed via the objects an optional
-	var indexImagePath = ""
+	var filePath = ""
+	var labelRange = ""
 	for _, obj := range objs {
 		switch obj.(type) {
 		case map[string]string:
-			indexImagePath = obj.(map[string]string)[IndexImagePathKey]
-			if len(indexImagePath) > 0 {
+			filePath = obj.(map[string]string)[FilePathKey]
+			if len(filePath) > 0 {
+				break
+			}
+			labelRange = obj.(map[string]string)[RangeKey]
+			if len(labelRange) > 0 {
 				break
 			}
 		}
@@ -48,22 +74,27 @@ func communityValidator(objs ...interface{}) (results []errors.ManifestResult) {
 	for _, obj := range objs {
 		switch v := obj.(type) {
 		case *manifests.Bundle:
-			results = append(results, validateCommunityBundle(v, indexImagePath))
+			results = append(results, validateCommunityBundle(v, filePath, labelRange))
 		}
 	}
 
 	return results
 }
 
+// CommunityOperatorChecks defines the attributes used to perform the checks
 type CommunityOperatorChecks struct {
-	bundle         manifests.Bundle
-	indexImagePath string
-	errs           []error
-	warns          []error
+	bundle           manifests.Bundle
+	filePath         string
+	labelRange       string
+	rangeValue       string
+	maxValue         string
+	deprecateAPIsMsg string
+	errs             []error
+	warns            []error
 }
 
 // validateCommunityBundle will check the bundle against the community-operator criterias
-func validateCommunityBundle(bundle *manifests.Bundle, indexImagePath string) errors.ManifestResult {
+func validateCommunityBundle(bundle *manifests.Bundle, indexImagePath string, labelRange string) errors.ManifestResult {
 	result := errors.ManifestResult{Name: bundle.Name}
 	if bundle == nil {
 		result.Add(errors.ErrInvalidBundle("Bundle is nil", nil))
@@ -75,21 +106,20 @@ func validateCommunityBundle(bundle *manifests.Bundle, indexImagePath string) er
 		return result
 	}
 
-	checks := CommunityOperatorChecks{bundle: *bundle, indexImagePath: indexImagePath, errs: []error{}, warns: []error{}}
-
-	deprecatedAPIs := getRemovedAPIsOn1_22From(bundle)
-	// Check if has deprecated apis then, check the olm.maxOpenShiftVersion property
-	if len(deprecatedAPIs) > 0 {
-		deprecatedAPIsMessage := generateMessageWithDeprecatedAPIs(deprecatedAPIs)
-		checks = checkMaxOpenShiftVersion(checks, deprecatedAPIsMessage)
-		checks = checkOCPLabelsWithHasDeprecatedAPIs(checks, deprecatedAPIsMessage)
-		for _, err := range checks.errs {
-			result.Add(errors.ErrInvalidCSV(err.Error(), bundle.CSV.GetName()))
-		}
-		for _, warn := range checks.warns {
-			result.Add(errors.WarnInvalidCSV(warn.Error(), bundle.CSV.GetName()))
-		}
+	checks := CommunityOperatorChecks{bundle: *bundle, filePath: indexImagePath, labelRange: labelRange, rangeValue: labelRange, errs: []error{}, warns: []error{}}
+	checks.deprecateAPIsMsg = getRemovedAPIsOn1_22From(bundle)
+	checks = getMaxAnnotationValue(checks)
+	checks = checkMaxVersionAnnotation(checks)
+	checks = getOCPLabel(checks)
+	checks = checkOCPLabel(checks)
+	checks = validateOCPLabelWithMaxVersion(checks)
+	for _, err := range checks.errs {
+		result.Add(errors.ErrInvalidCSV(err.Error(), bundle.CSV.GetName()))
 	}
+	for _, warn := range checks.warns {
+		result.Add(errors.WarnInvalidCSV(warn.Error(), bundle.CSV.GetName()))
+	}
+
 
 	return result
 }
@@ -99,242 +129,295 @@ type propertiesAnnotation struct {
 	Value string
 }
 
-// checkMaxOpenShiftVersion will verify if the OpenShiftVersion property was informed
-func checkMaxOpenShiftVersion(checks CommunityOperatorChecks, v1beta1MsgForResourcesFound string) CommunityOperatorChecks {
-	// Ensure that has the OCPMaxAnnotation
-	const olmproperties = "olm.properties"
-	const olmmaxOpenShiftVersion = "olm.maxOpenShiftVersion"
-	semVerOCPV1beta1Unsupported, _ := semver.ParseTolerant(ocpVerV1beta1Unsupported)
+
+// checkMaxVersionAnnotation will verify if the OpenShiftVersion property was informed
+func getMaxAnnotationValue(checks CommunityOperatorChecks) CommunityOperatorChecks {
 
 	properties := checks.bundle.CSV.Annotations[olmproperties]
 	if len(properties) == 0 {
-		checks.errs = append(checks.errs, fmt.Errorf("csv.Annotations not specified %s for an "+
-			"OCP version < %s. This annotation is required to prevent the user from upgrading their OCP cluster "+
-			"before they have installed a version of their operator which is compatible with %s. This bundle is using APIs which were deprecated and removed in v1.22. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22 which are no "+
-			"longer supported on %s. Migrate the API(s) for %s or use the annotation",
-			olmmaxOpenShiftVersion,
-			ocpVerV1beta1Unsupported,
-			ocpVerV1beta1Unsupported,
-			ocpVerV1beta1Unsupported,
-			v1beta1MsgForResourcesFound))
 		return checks
 	}
 
 	var properList []propertiesAnnotation
 	if err := json.Unmarshal([]byte(properties), &properList); err != nil {
 		checks.errs = append(checks.errs, fmt.Errorf("csv.Annotations has an invalid value specified for %s. "+
-			"Please, check the value  (%s) and ensure that it is an array such as: "+
+			"Please, check the value (%s) and ensure that it is an array such as: "+
 			"\"olm.properties\": '[{\"type\": \"key name\", \"value\": \"key value\"}]'",
 			olmproperties, properties))
 		return checks
 	}
 
-	hasOlmMaxOpenShiftVersion := false
-	olmMaxOpenShiftVersionValue := ""
 	for _, v := range properList {
-		if v.Type == olmmaxOpenShiftVersion {
-			hasOlmMaxOpenShiftVersion = true
-			olmMaxOpenShiftVersionValue = v.Value
+		if v.Type == olmmaxOcpVersion {
+			checks.maxValue = v.Value
 			break
 		}
 	}
 
-	if !hasOlmMaxOpenShiftVersion {
-		checks.errs = append(checks.errs, fmt.Errorf("csv.Annotations.%s with the "+
-			"key `%s` and a value with an OCP version which is < %s is required for any operator "+
-			"bundle that is using APIs which were deprecated and removed in v1.22. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22. Migrate the API(s) for %s or use the annotation",
-			olmproperties,
-			olmmaxOpenShiftVersion,
-			ocpVerV1beta1Unsupported,
-			v1beta1MsgForResourcesFound))
-		return checks
-	}
-
-	semVerVersionMaxOcp, err := semver.ParseTolerant(olmMaxOpenShiftVersionValue)
-	if err != nil {
-		checks.errs = append(checks.errs, fmt.Errorf("csv.Annotations.%s has an invalid value. "+
-			"Unable to parse (%s) using semver : %s",
-			olmproperties, olmMaxOpenShiftVersionValue, err))
-		return checks
-	}
-
-	truncatedMaxOcp := semver.Version{Major: semVerVersionMaxOcp.Major, Minor: semVerVersionMaxOcp.Minor}
-	if !semVerVersionMaxOcp.EQ(truncatedMaxOcp) {
-		checks.warns = append(checks.warns, fmt.Errorf("csv.Annotations.%s has an invalid value. "+
-			"%s must specify only major.minor versions, %s will be truncated to %s",
-			olmproperties, olmmaxOpenShiftVersion, semVerVersionMaxOcp, truncatedMaxOcp))
-		return checks
-	}
-
-	if semVerVersionMaxOcp.GE(semVerOCPV1beta1Unsupported) {
-		checks.errs = append(checks.errs, fmt.Errorf("csv.Annotations.%s with the "+
-			"key and value for %s has the OCP version value %s which is >= of %s. This bundle is using APIs which were deprecated and removed in v1.22. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22. "+
-			"Migrate the API(s) for %s "+
-			"or inform in this property an OCP version which is < %s",
-			olmproperties,
-			olmmaxOpenShiftVersion,
-			olmMaxOpenShiftVersionValue,
-			ocpVerV1beta1Unsupported,
-			v1beta1MsgForResourcesFound,
-			ocpVerV1beta1Unsupported))
-		return checks
-	}
-
 	return checks
 }
 
-// checkOCPLabels will ensure that OCP labels are set and with a ocp target < 4.9
-func checkOCPLabelsWithHasDeprecatedAPIs(checks CommunityOperatorChecks, deprecatedAPImsg string) CommunityOperatorChecks {
-	// Note that we cannot make mandatory because the package format still valid
-	if len(checks.indexImagePath) == 0 {
-		checks.warns = append(checks.errs, fmt.Errorf("please, inform the path of "+
-			"its index image file via the the optional key values and the key %s to allow this validator check the labels "+
-			"configuration or migrate the API(s) for %s. "+
-			"(e.g. %s=./mypath/bundle.Dockerfile). This bundle is using APIs which were deprecated and removed in v1.22. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22 ",
-			IndexImagePathKey,
-			deprecatedAPImsg,
-			IndexImagePathKey))
+// checkMaxVersionAnnotation will verify if the OpenShiftVersion property was informed
+func checkMaxVersionAnnotation(checks CommunityOperatorChecks) CommunityOperatorChecks {
+	if len(checks.deprecateAPIsMsg) > 0 && len(checks.maxValue) < 1 {
+		checks.errs = append(checks.errs, fmt.Errorf("csv.Annotations not specified %s for an "+
+			"OCP version < %s. This annotation is required to prevent the user from upgrading their OCP cluster "+
+			"before they have installed a version of their operator which is compatible with %s. This bundle is using APIs which were deprecated and removed in v1.22. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22 which are no "+
+			"longer supported on %s. Migrate the API(s) for %s or use the annotation",
+			olmmaxOcpVersion,
+			ocpVerV1beta1Unsupported,
+			ocpVerV1beta1Unsupported,
+			ocpVerV1beta1Unsupported,
+			checks.deprecateAPIsMsg))
 		return checks
 	}
 
-	return validateImageFile(checks, deprecatedAPImsg)
-}
+	if len(checks.maxValue) > 0 {
+		semVerVersionMaxOcp, err := semver.ParseTolerant(checks.maxValue)
+		if err != nil {
+			checks.errs = append(checks.errs, fmt.Errorf("csv.Annotations.%s has an invalid value. "+
+				"Unable to parse (%s) using semver : %s",
+				olmproperties, checks.maxValue, err))
+			return checks
+		}
 
-func validateImageFile(checks CommunityOperatorChecks, deprecatedAPImsg string) CommunityOperatorChecks {
-	if len(checks.indexImagePath) == 0 {
-		return checks
-	}
+		truncatedMaxOcp := semver.Version{Major: semVerVersionMaxOcp.Major, Minor: semVerVersionMaxOcp.Minor}
+		if !semVerVersionMaxOcp.EQ(truncatedMaxOcp) {
+			checks.warns = append(checks.warns, fmt.Errorf("csv.Annotations.%s has an invalid value. "+
+				"%s must specify only major.minor versions, %s will be truncated to %s",
+				olmproperties, olmmaxOcpVersion, semVerVersionMaxOcp, truncatedMaxOcp))
+			return checks
+		}
 
-	info, err := os.Stat(checks.indexImagePath)
-	if err != nil {
-		checks.errs = append(checks.errs, fmt.Errorf("the index image in the path "+
-			"(%s) was not found. Please, inform the path of the bundle operator index image via the the optional key values and the key %s. "+
-			"(e.g. %s=./mypath/bundle.Dockerfile). Error : %s", checks.indexImagePath, IndexImagePathKey, IndexImagePathKey, err))
-		return checks
-	}
-	if info.IsDir() {
-		checks.errs = append(checks.errs, fmt.Errorf("the index image in the path "+
-			"(%s) is not file. Please, inform the path of its index image via the the optional key values and the key %s. "+
-			"(e.g. %s=./mypath/bundle.Dockerfile). The value informed is a diretory and not a file", checks.indexImagePath, IndexImagePathKey, IndexImagePathKey))
-		return checks
-	}
-
-	b, err := ioutil.ReadFile(checks.indexImagePath)
-	if err != nil {
-		checks.errs = append(checks.errs, fmt.Errorf("unable to read the index image in the path "+
-			"(%s). Error : %s", checks.indexImagePath, err))
-		return checks
-	}
-
-	indexPathContent := string(b)
-	hasOCPLabel := strings.Contains(indexPathContent, ocpLabelindex)
-	if hasOCPLabel {
-		semVerOCPV1beta1Unsupported, _ := semver.ParseTolerant(ocpVerV1beta1Unsupported)
-		// the OCP range informed cannot allow carry on to OCP 4.9+
-		line := strings.Split(indexPathContent, "\n")
-		for i := 0; i < len(line); i++ {
-			if strings.Contains(line[i], ocpLabelindex) {
-				if !strings.Contains(line[i], "=") {
-					checks.errs = append(checks.errs, fmt.Errorf("invalid syntax (%s) for (%s)",
-						line[i],
-						ocpLabelindex))
-					return checks
-				}
-
-				value := strings.Split(line[i], "=")
-				// It means that the OCP label is =OCP version
-				if len(value) > 2 && len(value[2]) > 0 {
-					version := cleanStringToGetTheVersionToParse(value[2])
-					verParsed, err := semver.ParseTolerant(version)
-					if err != nil {
-						checks.errs = append(checks.errs, fmt.Errorf("unable to parse the value (%s) on (%s)",
-							version, ocpLabelindex))
-						return checks
-					}
-
-					if verParsed.GE(semVerOCPV1beta1Unsupported) {
-						checks.errs = append(checks.errs, fmt.Errorf("this bundle is using APIs which were "+
-							"deprecated and removed in v1.22. "+
-							"More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22. "+
-							"Migrate the API(s) for "+
-							"%s or provide compatible version(s) by using the %s annotation in "+
-							"`metadata/annotations.yaml` to ensure that the index image will be geneared "+
-							"with its label. (e.g. LABEL %s='4.6-4.8')",
-							deprecatedAPImsg,
-							ocpLabelindex,
-							ocpLabelindex))
-						return checks
-					}
-					return checks
-				}
-				indexRange := cleanStringToGetTheVersionToParse(value[1])
-				if len(indexRange) > 1 {
-					// if has the = then, the value needs to be < 4.9
-					// if not has not the = then the value needs contains - value less < 4.9
-					if !strings.Contains(indexRange, "-") {
-						checks.errs = append(checks.errs, fmt.Errorf("this bundle is using APIs which were "+
-							"deprecated and removed in v1.22. "+
-							"More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22 "+
-							"The %s allows to distribute it on >= %s. Migrate the API(s) for "+
-							"%s or provide compatible version(s) by using the %s annotation in "+
-							"`metadata/annotations.yaml` to ensure that the index image will be generated "+
-							"with its label. (e.g. LABEL %s='4.6-4.8')",
-							indexRange,
-							ocpVerV1beta1Unsupported,
-							deprecatedAPImsg,
-							ocpLabelindex,
-							ocpLabelindex))
-						return checks
-					}
-
-					version := strings.Split(indexRange, "-")[1]
-					verParsed, err := semver.ParseTolerant(version)
-					if err != nil {
-						checks.errs = append(checks.errs, fmt.Errorf("unable to parse the value (%s) on (%s)",
-							version, ocpLabelindex))
-						return checks
-					}
-
-					if verParsed.GE(semVerOCPV1beta1Unsupported) {
-						checks.errs = append(checks.errs, fmt.Errorf("this bundle is using APIs which were "+
-							"deprecated and removed in v1.22. "+
-							"More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22. "+
-							"Upgrade the APIs from "+
-							"for %s or provide compatible distribution version(s) by using the %s "+
-							"annotation in `metadata/annotations.yaml` to ensure that the index image will "+
-							"be generated with its label. (e.g. LABEL %s='4.6-4.8')",
-							deprecatedAPImsg,
-							ocpLabelindex,
-							ocpLabelindex))
-						return checks
-					}
-				} else {
-					checks.errs = append(checks.errs, fmt.Errorf("unable to get the range informed on %s",
-						ocpLabelindex))
-					return checks
-				}
-				break
+		if len(checks.deprecateAPIsMsg) > 0 {
+			semVerOCPV1beta1Unsupported, _ := semver.ParseTolerant(ocpVerV1beta1Unsupported)
+			if semVerVersionMaxOcp.GE(semVerOCPV1beta1Unsupported) {
+				checks.errs = append(checks.errs, fmt.Errorf("csv.Annotations.%s with the "+
+					"key and value for %s has the OCP version value %s which is >= of %s. This bundle is using APIs which were deprecated and removed in v1.22. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22. "+
+					"Migrate the API(s) for %s "+
+					"or inform in this property an OCP version which is < %s",
+					olmproperties,
+					olmmaxOcpVersion,
+					checks.maxValue,
+					ocpVerV1beta1Unsupported,
+					checks.deprecateAPIsMsg,
+					ocpVerV1beta1Unsupported))
+				return checks
 			}
 		}
-	} else {
-		checks.errs = append(checks.errs, fmt.Errorf("this bundle is using APIs which were deprecated and "+
-			"removed in v1.22. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22. "+
-			"Migrate the APIs "+
-			"for %s or provide compatible version(s) via the labels. (e.g. LABEL %s='4.6-4.8')",
-			deprecatedAPImsg,
-			ocpLabelindex))
-		return checks
+	}
+
+	return checks
+}
+
+
+// checkOCPLabels will ensure that OCP labels are set and with a ocp targetVersion < 4.9
+func getOCPLabel(checks CommunityOperatorChecks) CommunityOperatorChecks {
+	if hasOCPLabelInfo(checks) {
+		if len(checks.labelRange) > 0 {
+			return checks
+		}
+		return getOCPLabelFromFile(checks)
 	}
 	return checks
+}
+
+
+// checkOCPLabels will ensure that OCP labels are set and with a ocp targetVersion < 4.9
+func checkOCPLabel(checks CommunityOperatorChecks) CommunityOperatorChecks {
+	// Note that we cannot make mandatory because the package format still valid
+	if hasOCPLabelInfo(checks) && len(checks.rangeValue) == 0 {
+		if len(checks.deprecateAPIsMsg) > 0 {
+			checks.errs = append(checks.errs, fmt.Errorf(deprecateOcpLabelMsg1_22,
+				checks.deprecateAPIsMsg,
+				ocpLabel))
+		} else {
+			checks.warns = append(checks.warns, fmt.Errorf("unable to find %s configuration", ocpLabel))
+		}
+	}
+
+	return checkOCPLabelFor4_9(checks)
+}
+
+func hasOCPLabelInfo(checks CommunityOperatorChecks) bool {
+	return len(checks.filePath) != 0 || len(checks.labelRange) != 0
+}
+
+func getOCPLabelFromFile(checks CommunityOperatorChecks) CommunityOperatorChecks {
+	if len(checks.filePath) > 0 {
+		info, err := os.Stat(checks.filePath)
+		if err != nil {
+			checks.errs = append(checks.errs, fmt.Errorf("the file path informed (%s) was not found. "+
+				"Error : %s", checks.filePath, err))
+			return checks
+		}
+		if info.IsDir() {
+			checks.errs = append(checks.errs, fmt.Errorf("the file path informed (%s) is not a file",
+				checks.filePath))
+			return checks
+		}
+
+		b, err := ioutil.ReadFile(checks.filePath)
+		if err != nil {
+			checks.errs = append(checks.errs, fmt.Errorf("unable to read the index image in the path "+
+				"(%s). Error : %s", checks.filePath, err))
+			return checks
+		}
+
+		indexPathContent := string(b)
+		hasOCPLabel := strings.Contains(indexPathContent, ocpLabel)
+		if hasOCPLabel {
+			line := strings.Split(indexPathContent, "\n")
+			for i := 0; i < len(line); i++ {
+				if strings.Contains(line[i], ocpLabel) {
+					if !strings.Contains(line[i], "=") && !strings.Contains(line[i], ":") {
+						checks.errs = append(checks.errs, fmt.Errorf("invalid syntax (%s) for (%s)",
+							line[i],
+							ocpLabel))
+						return checks
+					}
+
+					value := strings.Split(line[i], ocpLabel)
+					if len(value[1]) == 0 {
+						checks.errs = append(checks.errs, fmt.Errorf("invalid syntax (%s) for (%s)",
+							line[i],
+							ocpLabel))
+						return checks
+					}
+					checks.rangeValue = cleanStringToGetTheVersionToParse(value[1])
+					break
+				}
+			}
+		}
+	}
+	return checks
+}
+
+
+
+func validateOCPLabelWithMaxVersion(checks CommunityOperatorChecks) CommunityOperatorChecks {
+	if len(checks.maxValue) > 0 && len(checks.rangeValue) > 0 {
+		isPartOfTarget, err := rangeContainsVersion(checks.rangeValue, cleanStringToGetTheVersionToParse(checks.maxValue), true)
+		if err != nil {
+			checks.errs = append(checks.errs, fmt.Errorf("error invalid label range %s",
+				err))
+			return checks
+		}
+		if !isPartOfTarget {
+			checks.errs = append(checks.errs, fmt.Errorf("the %s annotation to block the cluster upgrade" +
+				"does not contain in the range %s of versions where this solution should be distributed",
+				checks.maxValue,
+				checks.rangeValue))
+			return checks
+		}
+	}
+	return checks
+}
+
+// todo: the ocp targetVersion version ought to be passed as parameter
+// this code needs to be improved with the check for deprecated apis before/for 1.25
+func checkOCPLabelFor4_9(checks CommunityOperatorChecks) CommunityOperatorChecks {
+	if len(checks.deprecateAPIsMsg) > 0 && len(checks.rangeValue) > 0  {
+		isPartOfTarget, err := rangeContainsVersion(checks.rangeValue, ocpVerV1beta1Unsupported, false)
+		if err != nil {
+			checks.errs = append(checks.errs, fmt.Errorf("error to validate the OpenShit label range: %s",
+				err))
+			return checks
+		}
+		if isPartOfTarget {
+			checks.errs = append(checks.errs, fmt.Errorf("this bundle is using APIs which were "+
+				"deprecated and removed in v1.22. "+
+				"More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22. "+
+				"Migrate the API(s) for "+
+				"%s or provide compatible version(s) by using the %s annotation in "+
+				"`metadata/annotations.yaml` to ensure that the index image will be geneared "+
+				"with its label. (e.g. LABEL %s='4.6-4.8')",
+				checks.deprecateAPIsMsg,
+				ocpLabel,
+				ocpLabel))
+		}
+	}
+	return checks
+}
+
+// rangeContainsVersion expected the range and the targetVersion version and returns true
+// when the targetVersion version contains in the range
+func rangeContainsVersion(r string, v string, tolerantParse bool) (bool, error) {
+	if len(r) == 0 {
+		return false, golangerrors.New("range is empty")
+	}
+	if len(v) == 0 {
+		return false, golangerrors.New("version is empty")
+	}
+
+	v = strings.TrimPrefix(v, "v")
+	compV, err := semver.Parse(v + ".0")
+	if err != nil {
+		splitTarget :=strings.Split(v, ".")
+		if tolerantParse {
+			compV, err = semver.Parse(splitTarget[0] +"." + splitTarget[1] + ".0")
+			if err != nil {
+				return false, fmt.Errorf("invalid truncated version %q: %t", compV, err)
+			}
+		} else {
+			return false, fmt.Errorf("invalid version %q: %t", v, err)
+		}
+	}
+
+	// special legacy cases
+	if r == "v4.5,v4.6" || r == "v4.6,v4.5" {
+		semverRange := semver.MustParseRange(">=4.5.0")
+		return semverRange(compV), nil
+	}
+
+	var semverRange semver.Range
+	rs := strings.SplitN(r, "-", 2)
+	switch len(rs) {
+	case 1:
+		// Range specify exact version
+		if strings.HasPrefix(r, "=") {
+			trimmed := strings.TrimPrefix(r, "=v")
+			semverRange, err = semver.ParseRange(fmt.Sprintf("%s.0", trimmed))
+		} else {
+			trimmed := strings.TrimPrefix(r, "v")
+			// Range specifies minimum version
+			semverRange, err = semver.ParseRange(fmt.Sprintf(">=%s.0", trimmed))
+		}
+		if err != nil {
+			return false, fmt.Errorf("invalid range %q: %v", r, err)
+		}
+	case 2:
+		min := rs[0]
+		max := rs[1]
+		if strings.HasPrefix(min, "=") || strings.HasPrefix(max, "=") {
+			return false, fmt.Errorf("invalid range %q: cannot use equal prefix with range", r)
+		}
+		min = strings.TrimPrefix(min, "v")
+		max = strings.TrimPrefix(max, "v")
+		semverRangeStr := fmt.Sprintf(">=%s.0 <=%s.0", min, max)
+		semverRange, err = semver.ParseRange(semverRangeStr)
+		if err != nil {
+			return false, fmt.Errorf("invalid range %q: %v", r, err)
+		}
+	default:
+		return false, fmt.Errorf("invalid range %q", r)
+	}
+	return semverRange(compV), nil
 }
 
 // cleanStringToGetTheVersionToParse will remove the expected characters for
 // we are able to parse the version informed.
 func cleanStringToGetTheVersionToParse(value string) string {
+	// requires remove the possible double and single quotes which
+	// are faced after read/parse the file.
 	doubleQuote := "\""
 	singleQuote := "'"
 	value = strings.ReplaceAll(value, singleQuote, "")
 	value = strings.ReplaceAll(value, doubleQuote, "")
-	value = strings.ReplaceAll(value, "v", "")
+	// requires remove = when the file informed is a index image
+	value = strings.TrimPrefix(value, "=")
+	// requires remove : and spaces when the file informed is annotation
+	value = strings.TrimPrefix(value, ":")
+	value = strings.TrimSpace(value)
 	return value
 }

--- a/pkg/validation/internal/community_test.go
+++ b/pkg/validation/internal/community_test.go
@@ -2,16 +2,18 @@ package internal
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/operator-framework/api/pkg/manifests"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func Test_communityValidator(t *testing.T) {
 	type args struct {
-		annotations    map[string]string
-		bundleDir      string
-		imageIndexPath string
+		annotations   map[string]string
+		bundleDir     string
+		filePath      string
+		ocpLabelRange string
 	}
 	tests := []struct {
 		name        string
@@ -33,8 +35,31 @@ func Test_communityValidator(t *testing.T) {
 				"value < 4.9 and has deprecated apis",
 			wantError: false,
 			args: args{
-				bundleDir:      "./testdata/valid_bundle_v1beta1",
-				imageIndexPath: "./testdata/dockerfile/valid_bundle.Dockerfile",
+				bundleDir: "./testdata/valid_bundle_v1beta1",
+				annotations: map[string]string{
+					"olm.properties": fmt.Sprintf(`[{"type": "olm.maxOpenShiftVersion", "value": "4.8"}]`),
+				},
+			},
+		},
+		{
+			name: "should pass when the olm annotation and the label in the annotation file is set with a " +
+				"value < 4.9 and has deprecated apis",
+			wantError: false,
+			args: args{
+				bundleDir: "./testdata/valid_bundle_v1beta1",
+				filePath:  "./testdata/annotations/annotations.yaml",
+				annotations: map[string]string{
+					"olm.properties": fmt.Sprintf(`[{"type": "olm.maxOpenShiftVersion", "value": "4.8"}]`),
+				},
+			},
+		},
+		{
+			name: "should pass when the olm annotation and index label are set with a " +
+				"value < 4.9 and has deprecated apis and with label flag v4.6-v4.8",
+			wantError: false,
+			args: args{
+				bundleDir:     "./testdata/valid_bundle_v1beta1",
+				ocpLabelRange: "v4.6-v4.8",
 				annotations: map[string]string{
 					"olm.properties": fmt.Sprintf(`[{"type": "olm.maxOpenShiftVersion", "value": "4.8"}]`),
 				},
@@ -44,8 +69,8 @@ func Test_communityValidator(t *testing.T) {
 			name:      "should fail because is missing the olm.annotation and has deprecated apis",
 			wantError: true,
 			args: args{
-				bundleDir:      "./testdata/valid_bundle_v1beta1",
-				imageIndexPath: "./testdata/dockerfile/valid_bundle.Dockerfile",
+				bundleDir: "./testdata/valid_bundle_v1beta1",
+				filePath:  "./testdata/dockerfile/valid_bundle.Dockerfile",
 			},
 			errStrings: []string{"Error: Value : (etcdoperator.v0.9.4) csv.Annotations not specified " +
 				"olm.maxOpenShiftVersion for an OCP version < 4.9. This annotation is required to " +
@@ -56,28 +81,11 @@ func Test_communityValidator(t *testing.T) {
 				"longer supported on 4.9. Migrate the API(s) for CRD: ([\"etcdbackups.etcd.database.coreos.com\" \"etcdclusters.etcd.database.coreos.com\" \"etcdrestores.etcd.database.coreos.com\"]) or use the annotation"},
 		},
 		{
-			name: "should fail when the olm annotation is set without the properties for max ocp version and has " +
-				"deprecated apis",
-			wantError: true,
-			args: args{
-				bundleDir:      "./testdata/valid_bundle_v1beta1",
-				imageIndexPath: "./testdata/dockerfile/valid_bundle.Dockerfile",
-				annotations: map[string]string{
-					"olm.properties": fmt.Sprintf(`[{"type": "olm.invalid", "value": "4.9"}]`),
-				},
-			},
-			errStrings: []string{"Error: Value : (etcdoperator.v0.9.4) csv.Annotations.olm.properties with the key " +
-				"`olm.maxOpenShiftVersion` and a value with an OCP version which is < 4.9 is required for any operator " +
-				"bundle that is using APIs which were deprecated and removed in v1.22. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22. " +
-				"Migrate the API(s) for CRD: ([\"etcdbackups.etcd.database.coreos.com\" \"etcdclusters.etcd.database.coreos.com\" \"etcdrestores.etcd.database.coreos.com\"]) " +
-				"or use the annotation"},
-		},
-		{
 			name:      "should fail when the olm annotation is set with a value >= 4.9 and has deprecated apis",
 			wantError: true,
 			args: args{
-				bundleDir:      "./testdata/valid_bundle_v1beta1",
-				imageIndexPath: "./testdata/dockerfile/valid_bundle.Dockerfile",
+				bundleDir: "./testdata/valid_bundle_v1beta1",
+				filePath:  "./testdata/dockerfile/valid_bundle.Dockerfile",
 				annotations: map[string]string{
 					"olm.properties": fmt.Sprintf(`[{"type": "olm.maxOpenShiftVersion", "value": "4.9"}]`),
 				},
@@ -85,31 +93,17 @@ func Test_communityValidator(t *testing.T) {
 			errStrings: []string{"Error: Value : (etcdoperator.v0.9.4) csv.Annotations.olm.properties with the key " +
 				"and value for olm.maxOpenShiftVersion has the OCP version value 4.9 which is >= of 4.9. " +
 				"This bundle is using APIs which were deprecated and removed in v1.22. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22." +
-				" Migrate the API(s) for CRD: ([\"etcdbackups.etcd.database.coreos.com\" \"etcdclusters.etcd.database.coreos.com\" \"etcdrestores.etcd.database.coreos.com\"]) or inform in this property an OCP version which is < 4.9"},
-		},
-		{
-			name:        "should warning because is missing the index-path and has deprecated apis",
-			wantWarning: true,
-			args: args{
-				bundleDir: "./testdata/valid_bundle_v1beta1",
-				annotations: map[string]string{
-					"olm.properties": fmt.Sprintf(`[{"type": "olm.maxOpenShiftVersion", "value": "4.8"}]`),
-				},
+				" Migrate the API(s) for CRD: ([\"etcdbackups.etcd.database.coreos.com\" \"etcdclusters.etcd.database.coreos.com\" \"etcdrestores.etcd.database.coreos.com\"]) or inform in this property an OCP version which is < 4.9",
+				"Error: Value : (etcdoperator.v0.9.4) the 4.9 annotation to block the cluster upgradedoes not contain in the range v4.6-v4.8 of versions where this solution should be distributed",
+
 			},
-			warnStrings: []string{"Warning: Value : (etcdoperator.v0.9.4) please, inform the path of its index image " +
-				"file via the the optional key values and the key index-path to allow this validator check the labels " +
-				"configuration or migrate the API(s) for CRD: " +
-				"([\"etcdbackups.etcd.database.coreos.com\" \"etcdclusters.etcd.database.coreos.com\" " +
-				"\"etcdrestores.etcd.database.coreos.com\"]). (e.g. index-path=./mypath/bundle.Dockerfile). " +
-				"This bundle is using APIs which were deprecated and removed in v1.22. " +
-				"More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22 "},
 		},
 		{
 			name:        "should warn on patch version in maxOpenShiftVersion",
 			wantWarning: true,
 			args: args{
-				bundleDir:      "./testdata/valid_bundle_v1beta1",
-				imageIndexPath: "./testdata/dockerfile/valid_bundle.Dockerfile",
+				bundleDir: "./testdata/valid_bundle_v1beta1",
+				filePath:  "./testdata/dockerfile/valid_bundle.Dockerfile",
 				annotations: map[string]string{
 					"olm.properties": fmt.Sprintf(`[{"type": "olm.maxOpenShiftVersion", "value": "4.8.1"}]`),
 				},
@@ -122,8 +116,8 @@ func Test_communityValidator(t *testing.T) {
 			name:      "should pass when the maxOpenShiftVersion is semantically equivalent to <major>.<minor>.0",
 			wantError: false,
 			args: args{
-				bundleDir:      "./testdata/valid_bundle_v1beta1",
-				imageIndexPath: "./testdata/dockerfile/valid_bundle.Dockerfile",
+				bundleDir: "./testdata/valid_bundle_v1beta1",
+				filePath:  "./testdata/dockerfile/valid_bundle.Dockerfile",
 				annotations: map[string]string{
 					"olm.properties": fmt.Sprintf(`[{"type": "olm.maxOpenShiftVersion", "value": "4.8.0+build"}]`),
 				},
@@ -134,8 +128,8 @@ func Test_communityValidator(t *testing.T) {
 				"value =v4.8 and has deprecated apis",
 			wantError: false,
 			args: args{
-				bundleDir:      "./testdata/valid_bundle_v1beta1",
-				imageIndexPath: "./testdata/dockerfile/valid_bundle_4_8.Dockerfile",
+				bundleDir: "./testdata/valid_bundle_v1beta1",
+				filePath:  "./testdata/dockerfile/valid_bundle_4_8.Dockerfile",
 				annotations: map[string]string{
 					"olm.properties": fmt.Sprintf(`[{"type": "olm.maxOpenShiftVersion", "value": "4.8"}]`),
 				},
@@ -154,7 +148,7 @@ func Test_communityValidator(t *testing.T) {
 				bundle.CSV.Annotations = tt.args.annotations
 			}
 
-			results := validateCommunityBundle(bundle, tt.args.imageIndexPath)
+			results := validateCommunityBundle(bundle, tt.args.filePath, tt.args.ocpLabelRange)
 			require.Equal(t, tt.wantWarning, len(results.Warnings) > 0)
 			if tt.wantWarning {
 				require.Equal(t, len(tt.warnStrings), len(results.Warnings))
@@ -178,7 +172,7 @@ func Test_communityValidator(t *testing.T) {
 
 func Test_checkOCPLabelsWithHasDeprecatedAPIs(t *testing.T) {
 	type args struct {
-		checks    CSVChecks
+		checks    CommunityOperatorChecks
 		indexPath string
 	}
 	tests := []struct {
@@ -194,8 +188,9 @@ func Test_checkOCPLabelsWithHasDeprecatedAPIs(t *testing.T) {
 			},
 		},
 		{
-			name:      "should fail when the OCP label is not found",
-			wantError: true,
+			name:      "should warn when the OCP label is not found",
+			wantError: false,
+			wantWarning: true,
 			args: args{
 				indexPath: "./testdata/dockerfile/bundle_without_label.Dockerfile",
 			},
@@ -203,40 +198,108 @@ func Test_checkOCPLabelsWithHasDeprecatedAPIs(t *testing.T) {
 		{
 			name:      "should fail when the the index path is an invalid path",
 			wantError: true,
+			wantWarning: true,
 			args: args{
 				indexPath: "./testdata/dockerfile/invalid",
-			},
-		},
-		{
-			name:      "should fail when the OCP label index is => 4.9",
-			wantError: true,
-			args: args{
-				indexPath: "./testdata/dockerfile/invalid_bundle_equals_upper.Dockerfile",
-			},
-		},
-		{
-			name:      "should fail when the OCP label index range is => 4.9",
-			wantError: true,
-			args: args{
-				indexPath: "./testdata/dockerfile/invalid_bundle_range_upper.Dockerfile",
-			},
-		},
-		{
-			name:      "should fail when the OCP label index range is => 4.9 with coma e.g. v4.5,4.6",
-			wantError: true,
-			args: args{
-				indexPath: "./testdata/dockerfile/invalid_bundle_range_upper.Dockerfile",
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			checks := CommunityOperatorChecks{bundle: manifests.Bundle{}, indexImagePath: tt.args.indexPath, errs: []error{}, warns: []error{}}
-
-			checks = checkOCPLabelsWithHasDeprecatedAPIs(checks, "CRD: ([\"etcdbackups.etcd.database.coreos.com\" \"etcdclusters.etcd.database.coreos.com\" \"etcdrestores.etcd.database.coreos.com\"])")
-
+			checks := CommunityOperatorChecks{bundle: manifests.Bundle{}, filePath: tt.args.indexPath, errs: []error{}, warns: []error{}}
+			checks = getOCPLabel(checks)
+			checks = checkOCPLabel(checks)
 			require.Equal(t, tt.wantWarning, len(checks.warns) > 0)
 			require.Equal(t, tt.wantError, len(checks.errs) > 0)
+		})
+	}
+}
+
+func Test_rangeContainsVersion(t *testing.T) {
+	type args struct {
+		rangeValue    string
+		targetVersion string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:    "should return true when the label range is <= the targetVersion version",
+			wantErr: false,
+			want:    true,
+			args: args{
+				rangeValue:    "=v4.9",
+				targetVersion: "4.9",
+			},
+		},
+		{
+			name:    "should return false when the label range is > than targetVersion version",
+			wantErr: false,
+			want:    false,
+			args: args{
+				rangeValue:    "=v4.10",
+				targetVersion: "4.9",
+			},
+		},
+		{
+			name:    "should return false when the label range is > than targetVersion version (v4.10-v4.11) < 4.9",
+			wantErr: false,
+			want:    false,
+			args: args{
+				rangeValue:    "v4.10-v4.11",
+				targetVersion: "4.9",
+			},
+		},
+		{
+			name:    "should return invalid syntax",
+			wantErr: true,
+			want:    false,
+			args: args{
+				rangeValue:    "’”””v’”4v.vvv’”””8",
+				targetVersion: "4.9",
+			},
+		},
+		{
+			name:    "should return invalid syntax with vv4.vv8v-vvv4vvv.vvv9vvv",
+			wantErr: true,
+			want:    false,
+			args: args{
+				rangeValue:    "vv4.vv8v-vvv4vvv.vvv9vvv",
+				targetVersion: "4.9",
+			},
+		},
+		{
+			name:    "should return true when the label range is < than targetVersion version (v4.5-v4.8) < 4.9",
+			wantErr: false,
+			want:    false,
+			args: args{
+				rangeValue:    "v4.5-v4.8",
+				targetVersion: "4.9",
+			},
+		},
+		{
+			name:    "should return true when the label range is > than targetVersion version with comas (v4.5,v4.6) < 4.9",
+			wantErr: false,
+			want:    true,
+			args: args{
+				rangeValue:    "v4.5,v4.6",
+				targetVersion: "4.9",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := rangeContainsVersion(tt.args.rangeValue, tt.args.targetVersion, false)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("rangeContainsVersion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("rangeContainsVersion() got = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }

--- a/pkg/validation/internal/removed_apis.go
+++ b/pkg/validation/internal/removed_apis.go
@@ -127,13 +127,12 @@ func validateDeprecatedAPIS(bundle *manifests.Bundle, versionProvided string) (e
 	if !isVersionProvided || semVerVersionProvided.GE(semVerk8sVerV1betav1Deprecated) {
 		deprecatedAPIs := getRemovedAPIsOn1_22From(bundle)
 		if len(deprecatedAPIs) > 0 {
-			deprecatedAPIsMessage := generateMessageWithDeprecatedAPIs(deprecatedAPIs)
 			// isUnsupported is true only if the key/value OR minKubeVersion were informed and are >= 1.22
 			isUnsupported := semVerVersionProvided.GE(semVerK8sVerV1betav1Unsupported) ||
 				semverMinKube.GE(semVerK8sVerV1betav1Unsupported)
 			// We only raise an error when the version >= 1.22 was informed via
 			// the k8s key/value option or is specifically defined in the CSV
-			msg := fmt.Errorf("this bundle is using APIs which were deprecated and removed in v1.22. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22. Migrate the API(s) for %s", deprecatedAPIsMessage)
+			msg := fmt.Errorf("this bundle is using APIs which were deprecated and removed in v1.22. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22. Migrate the API(s) for %s", deprecatedAPIs)
 			if isUnsupported {
 				errs = append(errs, msg)
 			} else {
@@ -165,7 +164,7 @@ func generateMessageWithDeprecatedAPIs(deprecatedAPIs map[string][]string) strin
 
 // getRemovedAPIsOn1_22From return the list of resources which were deprecated
 // and are no longer be supported in 1.22. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22
-func getRemovedAPIsOn1_22From(bundle *manifests.Bundle) map[string][]string {
+func getRemovedAPIsOn1_22From(bundle *manifests.Bundle) string {
 	deprecatedAPIs := make(map[string][]string)
 	if len(bundle.V1beta1CRDs) > 0 {
 		var crdApiNames []string
@@ -226,5 +225,7 @@ func getRemovedAPIsOn1_22From(bundle *manifests.Bundle) map[string][]string {
 			}
 		}
 	}
-	return deprecatedAPIs
+
+	// Check if has deprecated apis then, check the olm.maxOpenShiftVersion property
+	return generateMessageWithDeprecatedAPIs(deprecatedAPIs)
 }

--- a/pkg/validation/internal/removed_apis_test.go
+++ b/pkg/validation/internal/removed_apis_test.go
@@ -8,46 +8,34 @@ import (
 )
 
 func Test_getDeprecatedAPIs(t *testing.T) {
-
-	// Mock the expected result for ./testdata/valid_bundle_v1beta1
-	crdMock := make(map[string][]string)
-	crdMock["CRD"] = []string{"etcdbackups.etcd.database.coreos.com", "etcdclusters.etcd.database.coreos.com", "etcdrestores.etcd.database.coreos.com"}
-
-	// Mock the expected result for ./testdata/valid_bundle_with_v1beta1_clusterrole
-	otherKindsMock := make(map[string][]string)
-	otherKindsMock[ClusterRoleKind] = []string{"memcached-operator-metrics-reader"}
-	otherKindsMock[PriorityClassKind] = []string{"super-priority"}
-	otherKindsMock[RoleKind] = []string{"memcached-role"}
-	otherKindsMock["MutatingWebhookConfiguration"] = []string{"mutating-webhook-configuration"}
-
 	type args struct {
 		bundleDir string
 	}
 	tests := []struct {
 		name string
 		args args
-		want map[string][]string
+		want string
 	}{
 		{
-			name: "should return an empty map when no deprecated apis are found",
+			name: "should return an empty string when no deprecated apis are found",
 			args: args{
 				bundleDir: "./testdata/valid_bundle_v1",
 			},
-			want: map[string][]string{},
+			want: "",
 		},
 		{
 			name: "should return map with CRDs when this kind of resource is deprecated",
 			args: args{
 				bundleDir: "./testdata/valid_bundle_v1beta1",
 			},
-			want: crdMock,
+			want: "CRD: ([\"etcdbackups.etcd.database.coreos.com\" \"etcdclusters.etcd.database.coreos.com\" \"etcdrestores.etcd.database.coreos.com\"])",
 		},
 		{
 			name: "should return map with others kinds which are deprecated",
 			args: args{
 				bundleDir: "./testdata/bundle_with_deprecated_resources",
 			},
-			want: otherKindsMock,
+			want: "ClusterRole: ([\"memcached-operator-metrics-reader\"]),PriorityClass: ([\"super-priority\"]),Role: ([\"memcached-role\"]),MutatingWebhookConfiguration: ([\"mutating-webhook-configuration\"]),",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/validation/internal/testdata/annotations/annotations.yaml
+++ b/pkg/validation/internal/testdata/annotations/annotations.yaml
@@ -1,0 +1,12 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: memcached-operator
+  operators.operatorframework.io.bundle.channels.v1: alpha
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/
+  com.redhat.openshift.versions: "=v4.8"


### PR DESCRIPTION
**Description**

- Make clear the desire to move it out of the operator framework/api in the long term
- Change the key option to allow receive the annotation or the dockerfile as requested
- Add option to allow pass only the range as well instead of the file
- Improve the test coverage
- check if max ocp version is compatible with OCP label range 

**Motivation**
- Some consumers would like to check it with the annotations, others with the index image and others only by informing a specific range
- Clarifies its stage in Alpha and addresses requests/feedbacks made so far

Note that still requires to follow up to allow us to pass an OCP/k8s version to be checked as well.
