### PR TITLE
Nit: Remove unnecessary log over the k8s version informed for the AlphaDeprecatedAPIs

### DIFF
--- a/pkg/validation/internal/removed_apis.go
+++ b/pkg/validation/internal/removed_apis.go
@@ -101,10 +101,7 @@ func validateDeprecatedAPIS(bundle *manifests.Bundle, versionProvided string) (e
 		semVerVersionProvided, err = semver.ParseTolerant(versionProvided)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("invalid value informed via the k8s key option : %s", versionProvided))
-		} else {
-			// we might want to return it as info instead of warning in the future.
-			warns = append(warns, fmt.Errorf("checking APIs against Kubernetes version : %s", versionProvided))
-		}
+		} 
 	}
 
 	// Transform the spec minKubeVersion in semver Version to compare

--- a/pkg/validation/internal/removed_apis_test.go
+++ b/pkg/validation/internal/removed_apis_test.go
@@ -85,8 +85,6 @@ func TestValidateDeprecatedAPIS(t *testing.T) {
 				minKubeVersion: "",
 				directory:      "./testdata/valid_bundle_v1beta1",
 			},
-			wantWarning: true,
-			warnStrings: []string{"checking APIs against Kubernetes version : 1.15"},
 		},
 		{
 			name: "should return a warning when has the CRD v1beta1 and minKubeVersion is informed",
@@ -108,8 +106,6 @@ func TestValidateDeprecatedAPIS(t *testing.T) {
 				minKubeVersion: "1.11.3",
 				directory:      "./testdata/valid_bundle_v1beta1",
 			},
-			wantWarning: true,
-			warnStrings: []string{"checking APIs against Kubernetes version : 1.15"},
 		},
 		{
 			name: "should return an error when the k8sVersion is >= 1.22 and has the deprecated API",
@@ -123,8 +119,6 @@ func TestValidateDeprecatedAPIS(t *testing.T) {
 				"More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22. " +
 				"Migrate the API(s) for CRD: ([\"etcdbackups.etcd.database.coreos.com\"" +
 				" \"etcdclusters.etcd.database.coreos.com\" \"etcdrestores.etcd.database.coreos.com\"])"},
-			wantWarning: true,
-			warnStrings: []string{"checking APIs against Kubernetes version : 1.22"},
 		},
 		{
 			name: "should return an error when the k8sVersion informed is invalid",


### PR DESCRIPTION
**Description**
Nit: Remove  unnecessary log over the k8s version informed for the AlphaDeprecatedAPIs  

PS.: In the future, we can re-add it to info level if we address the issue: https://github.com/operator-framework/api/issues/158