### PR TITLE
operatorhub: add check for bundle name size

### DIFF
--- a/pkg/validation/internal/operatorhub.go
+++ b/pkg/validation/internal/operatorhub.go
@@ -193,6 +193,12 @@ func checkBundleName(checks CSVChecks) CSVChecks {
 			"naming convention: <operator-name>.v<semver> e.g. memcached-operator.v0.0.1", checks.csv.Name))
 	}
 
+	if len(checks.csv.Name) > 63 {
+		checks.errs = append(checks.errs, fmt.Errorf("csv.metadata.Name %v has the size %d which is bigger than " +
+			"63 caracteres. The bundle name must be 63 characters or less because it will be used as k8s ownerref label " +
+			"which only allows max of 63 characters", checks.csv.Name, len(checks.csv.Name)))
+	}
+
 	return checks
 }
 

--- a/pkg/validation/internal/operatorhub_test.go
+++ b/pkg/validation/internal/operatorhub_test.go
@@ -255,6 +255,12 @@ func TestCheckBundleName(t *testing.T) {
 			warnStrings: []string{"csv.metadata.Name memcached-operator.v1.3 is not following the " +
 				"versioning convention (MAJOR.MINOR.PATCH e.g 0.0.1): https://semver.org/"},
 		},
+		{
+			name:        "should return a error when the bundle name is > 63",
+			args:        args{bundleName: "memcached-operatoroperatoroperatoroperatoroperatoroperatoroperatoroperatoroperatoroperatoroperatoroperator.v1.3.0"},
+			wantError: true,
+			errStrings: []string{"csv.metadata.Name memcached-operatoroperatoroperatoroperatoroperatoroperatoroperatoroperatoroperatoroperatoroperatoroperator.v1.3.0 has the size 113 which is bigger than 63 caracteres. The bundle name must be 63 characters or less because it will be used as k8s ownerref label which only allows max of 63 characters"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**Description**
Add check for bundle name size.
It will fail afterwords in OLM and in runtime and will not provide a nice msg.
In this way, we can prevent these scenarios by checking when we lint the bundle. 