### PR TITLE
Fix Scorecard configuration ServiceAccount tag

### DIFF
--- a/pkg/apis/scorecard/v1alpha3/configuration_types.go
+++ b/pkg/apis/scorecard/v1alpha3/configuration_types.go
@@ -24,7 +24,7 @@ type Configuration struct {
 	Storage Storage `json:"storage,omitempty" yaml:"storage,omitempty"`
 
 	// ServiceAccount is the service account under which scorecard tests are run. This field is optional. If left unset, the `default` service account will be used.
-	ServiceAccount string `json:"string,omitempty" yaml:"string,omitempty"`
+	ServiceAccount string `json:"serviceaccount,omitempty" yaml:"serviceaccount,omitempty"`
 }
 
 // StageConfiguration configures a set of tests to be run.


### PR DESCRIPTION
The tag that configures the serialization of the `ServiceAccount` field for the Scorecard configuration incorrectly names the field "string", which results in the `serviceaccount` field being empty after unmarshalling, therefore being ignored.
Update the tag to name the field `serviceaccount`