### PR TITLE
deprecate: CommunityValidator

### DIFF
--- a/pkg/validation/internal/community.go
+++ b/pkg/validation/internal/community.go
@@ -29,6 +29,11 @@ const ocpVerV1beta1Unsupported = "4.9"
 //
 // Note that this validator allows to receive a List of optional values as key=values. Currently, only the
 // `index-path` key is allowed. If informed, it will check the labels on the image index according to its criteria.
+//
+// Deprecated - The checks made for this validator were moved to the external one:
+// https://github.com/redhat-openshift-ecosystem/ocp-olm-catalog-validator
+//
+// Please no longer use this check it will be removed in the next releases.
 var CommunityOperatorValidator interfaces.Validator = interfaces.ValidatorFunc(communityValidator)
 
 func communityValidator(objs ...interface{}) (results []errors.ManifestResult) {

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -40,6 +40,10 @@ var OperatorGroupValidator = internal.OperatorGroupValidator
 
 // CommunityOperatorValidator implements Validator to validate bundle objects
 // for the Community Operator requirements.
+//
+// Deprecated - The checks made for this validator were moved to the external one:
+// https://github.com/redhat-openshift-ecosystem/ocp-olm-catalog-validator.
+// Please no longer use this check it will be removed in the next releases.
 var CommunityOperatorValidator = internal.CommunityOperatorValidator
 
 // AlphaDeprecatedAPIsValidator implements Validator to validate bundle objects


### PR DESCRIPTION
**Description**

Deprecate community validator.
These checks were moved to the external validator:
OCP OLM Catalog Validator

More info: https://github.com/redhat-openshift-ecosystem/ocp-olm-catalog-validator

**Motivation**
We reach the consensus that these checks would fit better in a specific repository since it is not required for any catalog shipped/consumed outside of OCP. 