### PR TITLE
csv_validator: add check to ensure that the example is a valid JSON

### DIFF
--- a/pkg/validation/internal/csv_test.go
+++ b/pkg/validation/internal/csv_test.go
@@ -5,10 +5,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/ghodss/yaml"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/api/pkg/validation/errors"
-
-	"github.com/ghodss/yaml"
 )
 
 func TestValidateCSV(t *testing.T) {
@@ -70,6 +69,16 @@ func TestValidateCSV(t *testing.T) {
 				},
 			},
 			filepath.Join("testdata", "badName.csv.yaml"),
+		},
+		{
+			validatorFuncTest{
+				description: "should fail when alm-examples is pretty format and is invalid",
+				wantErr:     true,
+				errors: []errors.Error{
+					errors.ErrInvalidParse("invalid example", "invalid character at 176\n [{\"apiVersion\":\"local.storage.openshift.io/v1\",\"kind\":\"LocalVolume\",\"metadata\":{\"name\":\"example\"},\"spec\":{\"storageClassDevices\":[{\"devicePaths\":[\"/dev/disk/by-id/ata-crucial\",]<--(see the invalid character)"),
+				},
+			},
+			filepath.Join("testdata", "invalid.alm-examples.csv.yaml"),
 		},
 	}
 	for _, c := range cases {

--- a/pkg/validation/internal/testdata/invalid.alm-examples.csv.yaml
+++ b/pkg/validation/internal/testdata/invalid.alm-examples.csv.yaml
@@ -1,0 +1,34 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[{"apiVersion":"local.storage.openshift.io/v1","kind":"LocalVolume","metadata":{"name":"example"},"spec":{"storageClassDevices":[{"devicePaths":["/dev/disk/by-id/ata-crucial",],"fsType": "ext4", "storageClassName": "foobar", "volumeMode": "Filesystem" } ] } }, { "apiVersion": "local.storage.openshift.io/v1alpha1", "kind": "LocalVolumeSet", "metadata": { "name": "example-localvolumeset" }, "spec": { "deviceInclusionSpec": { "deviceMechanicalProperties": [ "Rotational", "NonRotational" ], "deviceTypes": [ "RawDisk" ], "maxSize": "100G", "minSize": "10G" }, "maxDeviceCount": 10, "nodeSelector": { "nodeSelectorTerms": [ { "matchExpressions": [ { "key": "kubernetes.io/hostname", "operator": "In", "values": [ "worker-0", "worker-1" ] } ] } ] }, "storageClassName": "example-storageclass", "volumeMode": "Block" } }, { "apiVersion": "local.storage.openshift.io/v1alpha1", "kind": "LocalVolumeDiscovery", "metadata": { "name": "auto-discover-devices" }, "spec": { "nodeSelector": { "nodeSelectorTerms": [ { "matchExpressions": [ { "key":"kubernetes.io/hostname","operator":"In","values":["worker-0","worker-1"]}]}]}}}]'
+    capabilities: Basic Install
+  name: test-operator.v0.0.1
+  namespace: placeholder
+spec:
+  displayName: test-operator
+  install:
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - test-operator
+  links:
+  - name: Test Operator
+    url: https://test-operator.domain
+  maintainers:
+  - email: your@email.com
+    name: Maintainer Name
+  maturity: alpha
+  provider:
+    name: Provider Name
+    url: https://your.domain
+  version: 0.0.1


### PR DESCRIPTION
**Description**
csv_validator: add a check to ensure that the example is a valid JSON.
Note that when it fails we are pointing out where is the issue as well. 


**Motivation**
Closes: https://github.com/operator-framework/api/issues/116
Closes: https://github.com/operator-framework/api/pull/115