### PR TITLE
.github/workflows: Add workflow_dispatch event trigger

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -1,11 +1,12 @@
 name: Go
 on:
   push:
-    branches: 
+    branches:
       - master
   pull_request:
-    branches: 
+    branches:
       - master
+  workflow_dispatch:
 jobs:
   build:
     name: Build

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths:
       - '**'
+  workflow_dispatch:
 jobs:
   verify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Update the go/verify workflows and specify the `workflow_dispatch` event
trigger, so operator-framework members can trigger CI runs of these
workflow definitions without having to open "empty" PRs.

Signed-off-by: timflannagan <timflannagan@gmail.com>