### PR TITLE
feat: add warning for olm.properties being defined when validating csv

### DIFF
--- a/pkg/validation/errors/error.go
+++ b/pkg/validation/errors/error.go
@@ -101,6 +101,7 @@ const (
 	ErrorInvalidBundle            ErrorType = "BundleNotValid"
 	ErrorInvalidPackageManifest   ErrorType = "PackageManifestNotValid"
 	ErrorObjectFailedValidation   ErrorType = "ObjectFailedValidation"
+	ErrorPropertiesAnnotationUsed ErrorType = "PropertiesAnnotationUsed"
 )
 
 func NewError(t ErrorType, detail, field string, v interface{}) Error {
@@ -242,4 +243,8 @@ func invalidObject(lvl Level, detail string, value interface{}) Error {
 
 func WarnInvalidObject(detail string, value interface{}) Error {
 	return failedValidation(LevelWarn, detail, value)
+}
+
+func WarnPropertiesAnnotationUsed(detail string) Error {
+	return Error{ErrorPropertiesAnnotationUsed, LevelWarn, "", "", detail}
 }

--- a/pkg/validation/internal/annotations.go
+++ b/pkg/validation/internal/annotations.go
@@ -9,6 +9,8 @@ import (
 	"github.com/operator-framework/api/pkg/validation/errors"
 )
 
+const olmpropertiesAnnotation = "olm.properties"
+
 // CaseSensitiveAnnotationKeySet is a set of annotation keys that are case sensitive
 // and can be used for validation purposes. The key is always lowercase and the value
 // contains the expected case sensitive string. This may not be an exhaustive list.
@@ -24,8 +26,9 @@ var CaseSensitiveAnnotationKeySet = map[string]string{
 /*
 ValidateAnnotationNames will check annotation keys to ensure they are using
 proper case. Uses CaseSensitiveAnnotationKeySet as a source for keys
-which are known to be case sensitive. This function can be used anywhere
-annotations need to be checked for case sensitivity.
+which are known to be case sensitive. It also checks to see if the olm.properties
+annotation is defined in order to add a warning if present. This function can be
+used anywhere annotations need to be checked for case sensitivity.
 
 Arguments
 
@@ -47,6 +50,16 @@ func ValidateAnnotationNames(annotations map[string]string, value interface{}) (
 				// annotation key supplied is invalid due to bad case.
 				errs = append(errs, errors.ErrFailedValidation(fmt.Sprintf("provided annotation %s uses wrong case and should be %s instead", annotationKey, knownCaseSensitiveKey), value))
 			}
+		}
+
+		if annotationKey == olmpropertiesAnnotation {
+			errs = append(
+				errs,
+				errors.WarnPropertiesAnnotationUsed(
+					fmt.Sprintf(
+						"found %s annotation, please define these properties in metadata/properties.yaml instead",
+						annotationKey,
+					)))
 		}
 	}
 	return errs

--- a/pkg/validation/internal/community.go
+++ b/pkg/validation/internal/community.go
@@ -3,10 +3,11 @@ package internal
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/blang/semver"
 	"io/ioutil"
 	"os"
 	"strings"
+
+	"github.com/blang/semver"
 
 	"github.com/operator-framework/api/pkg/manifests"
 	"github.com/operator-framework/api/pkg/validation/errors"

--- a/pkg/validation/internal/csv_test.go
+++ b/pkg/validation/internal/csv_test.go
@@ -1,14 +1,15 @@
 package internal
 
 import (
+	"fmt"
 	"io/ioutil"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"path/filepath"
 	"testing"
 
 	"github.com/ghodss/yaml"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/api/pkg/validation/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func TestValidateCSV(t *testing.T) {
@@ -91,7 +92,23 @@ func TestValidateCSV(t *testing.T) {
 			},
 			filepath.Join("testdata", "correct.csv.empty.example.yaml"),
 		},
+		{
+			validatorFuncTest{
+				description: "should warn when olm.properties are defined in the annotations",
+				wantWarn:    true,
+				errors: []errors.Error{
+					errors.WarnPropertiesAnnotationUsed(
+						fmt.Sprintf(
+							"found %s annotation, please define these properties in metadata/properties.yaml instead",
+							olmpropertiesAnnotation,
+						),
+					),
+				},
+			},
+			filepath.Join("testdata", "correct.csv.olm.properties.annotation.yaml"),
+		},
 	}
+
 	for _, c := range cases {
 		b, err := ioutil.ReadFile(c.csvPath)
 		if err != nil {

--- a/pkg/validation/internal/testdata/correct.csv.olm.properties.annotation.yaml
+++ b/pkg/validation/internal/testdata/correct.csv.olm.properties.annotation.yaml
@@ -1,0 +1,60 @@
+#! validate-crd: deploy/chart/templates/0000_30_02-clusterserviceversion.crd.yaml
+#! parse-kind: ClusterServiceVersion
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: etcdoperator.v0.9.0
+  namespace: placeholder
+  annotations:
+    alm-examples: '[{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdCluster","metadata":{"name":"example","namespace":"default"},"spec":{"size":3,"version":"3.2.13"}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdRestore","metadata":{"name":"example-etcd-cluster"},"spec":{"etcdCluster":{"name":"example-etcd-cluster"},"backupStorageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdBackup","metadata":{"name":"example-etcd-cluster-backup"},"spec":{"etcdEndpoints":["<etcd-cluster-endpoints>"],"storageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}}]'
+    olm.properties: '[{"type": "foo", "value": "bar"}]'
+spec:
+  version: 0.9.0
+  installModes:
+  - type: AllNamespaces
+    supported: true
+  install:
+    strategy: deployment
+    spec:
+      permissions:
+      - serviceAccountName: etcd-operator
+        rules:
+        - apiGroups:
+          - etcd.database.coreos.com
+          resources:
+          - etcdclusters
+          - etcdbackups
+          - etcdrestores
+          verbs:
+          - "*"
+      deployments:
+      - name: etcd-operator
+        spec:
+          replicas: 1
+          template:
+            metadata:
+              name: etcd-operator-alm-owned
+              labels:
+                name: etcd-operator-alm-owned
+            spec:
+              serviceAccountName: etcd-operator
+              containers:
+              - name: etcd-operator
+                command:
+                - etcd-operator
+                - --create-crd=false
+                image: quay.io/coreos/etcd-operator@sha256:db563baa8194fcfe39d1df744ed70024b0f1f9e9b55b5923c2f3a413c44dc6b8
+                env:
+                - name: MY_POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: MY_POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+  customresourcedefinitions:
+    owned:
+    - name: etcdclusters.etcd.database.coreos.com
+      version: v1beta2
+      kind: EtcdCluster


### PR DESCRIPTION
## Summary
To sufficiently address this [BZ](https://bugzilla.redhat.com/show_bug.cgi?id=2018095), this PR adds a warning when a user has defined the same property in the CSV's olm.properties annotation as well as in a properties.yaml. This will act as a soft barrier to users doing this in the future.

## Why this is needed
As the `olm.properties` annotation currently exists to just maintain backwards compatibility, we should warn newly created bundles from using it. Instead, it is a good idea to push them to use the `metadata/properties.yaml` file.