### PR TITLE
refactor(constraint): update none compound constraint to be not

### DIFF
--- a/pkg/constraints/constraint.go
+++ b/pkg/constraints/constraint.go
@@ -25,14 +25,15 @@ type Constraint struct {
 	// GVK defines a constraint for a GVK.
 	GVK *GVKConstraint `json:"gvk,omitempty" yaml:"gvk,omitempty"`
 
-	// All, Any, and None are compound constraints. See this enhancement for details:
+	// All, Any, and Not are compound constraints. See this enhancement for details:
 	// https://github.com/operator-framework/enhancements/blob/master/enhancements/compound-bundle-constraints.md
 	All *CompoundConstraint `json:"all,omitempty" yaml:"all,omitempty"`
 	Any *CompoundConstraint `json:"any,omitempty" yaml:"any,omitempty"`
-	// A note on None: this constraint is not particularly useful by itself.
+	// A note on Not: this constraint isn't particularly useful by itself.
 	// It should be used within an All constraint alongside some other constraint type
-	// since saying "none of these GVKs/packages/etc." without an alternative doesn't make sense.
-	None *CompoundConstraint `json:"none,omitempty" yaml:"none,omitempty"`
+	// since saying "do not use any of these GVKs/packages/etc." without an alternative
+	// doesn't make sense.
+	Not *CompoundConstraint `json:"not,omitempty" yaml:"not,omitempty"`
 }
 
 // CompoundConstraint holds a list of potentially nested constraints

--- a/pkg/constraints/constraint_test.go
+++ b/pkg/constraints/constraint_test.go
@@ -65,11 +65,11 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
-			name:  "Valid/BasicNone",
-			input: json.RawMessage(fmt.Sprintf(inputBasicCompoundTmpl, "none")),
+			name:  "Valid/BasicNot",
+			input: json.RawMessage(fmt.Sprintf(inputBasicCompoundTmpl, "not")),
 			expConstraint: Constraint{
 				FailureMessage: "blah",
-				None: &CompoundConstraint{
+				Not: &CompoundConstraint{
 					Constraints: []Constraint{
 						{
 							FailureMessage: "blah blah",
@@ -109,7 +109,7 @@ func TestParse(t *testing.T) {
 							},
 						},
 						{
-							None: &CompoundConstraint{
+							Not: &CompoundConstraint{
 								Constraints: []Constraint{
 									{GVK: &GVKConstraint{Group: "bazs.example.com", Kind: "Baz", Version: "v1alpha1"}},
 								},
@@ -256,7 +256,7 @@ const (
 			}
 		},
 		{
-			"none": {
+			"not": {
 				"constraints": [
 					{
 						"gvk": {


### PR DESCRIPTION
Signed-off-by: Tyler Slaton <tyslaton@redhat.com>

# Summary
Updating this code to fit the [new recent changes to the compound constraints EP](https://github.com/operator-framework/enhancements/pull/108) in an effort to make this UX clearer. This PR simple updates the code to reference `not` instead of `none`.