### PR TITLE
fix(constraints): bring back the none constraint and add a not alias for it

### DIFF
--- a/pkg/constraints/constraint.go
+++ b/pkg/constraints/constraint.go
@@ -29,11 +29,15 @@ type Constraint struct {
 	// https://github.com/operator-framework/enhancements/blob/master/enhancements/compound-bundle-constraints.md
 	All *CompoundConstraint `json:"all,omitempty" yaml:"all,omitempty"`
 	Any *CompoundConstraint `json:"any,omitempty" yaml:"any,omitempty"`
-	// A note on Not: this constraint isn't particularly useful by itself.
+	// A note on Not: this constraint is not particularly useful by itself.
 	// It should be used within an All constraint alongside some other constraint type
 	// since saying "do not use any of these GVKs/packages/etc." without an alternative
-	// doesn't make sense.
+	// doesn't make sense. Both Not and None can be used for this type but None is
+	// deprecated. If values for both Not and None are defined, None will be ignored
+	// as Not is preferred.
 	Not *CompoundConstraint `json:"not,omitempty" yaml:"not,omitempty"`
+	// Deprecated: Use Not instead. This has been deprecated as Not has a clearer UX.
+	None *CompoundConstraint `json:"none,omitempty" yaml:"none,omitempty"`
 }
 
 // CompoundConstraint holds a list of potentially nested constraints

--- a/pkg/constraints/constraint_test.go
+++ b/pkg/constraints/constraint_test.go
@@ -80,6 +80,21 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
+			name:  "Valid/BasicNone",
+			input: json.RawMessage(fmt.Sprintf(inputBasicCompoundTmpl, "none")),
+			expConstraint: Constraint{
+				FailureMessage: "blah",
+				None: &CompoundConstraint{
+					Constraints: []Constraint{
+						{
+							FailureMessage: "blah blah",
+							Package:        &PackageConstraint{PackageName: "fuz", VersionRange: ">=1.0.0"},
+						},
+					},
+				},
+			},
+		},
+		{
 			name:  "Valid/Complex",
 			input: json.RawMessage(inputComplex),
 			expConstraint: Constraint{


### PR DESCRIPTION
Signed-off-by: Tyler Slaton <tyslaton@redhat.com>

# Summary
A mistake was made where the None property was removed instead of just adding an alias for it. This PR adds back None, makes Not the default, and leaves "deprecated" comment on the None property.