### PR TITLE
Add "Migration and Modernization" category

### DIFF
--- a/pkg/validation/internal/operatorhub.go
+++ b/pkg/validation/internal/operatorhub.go
@@ -53,6 +53,8 @@ import (
 //
 // * Logging & Tracing
 //
+// * Migration and Modernization
+//
 // * Modernization & Migration
 //
 // * Monitoring
@@ -141,21 +143,22 @@ var validMediatypes = map[string]struct{}{
 }
 
 var validCategories = map[string]struct{}{
-	"AI/Machine Learning":       {},
-	"Application Runtime":       {},
-	"Big Data":                  {},
-	"Cloud Provider":            {},
-	"Developer Tools":           {},
-	"Database":                  {},
-	"Integration & Delivery":    {},
-	"Logging & Tracing":         {},
-	"Monitoring":                {},
-	"Modernization & Migration": {},
-	"Networking":                {},
-	"OpenShift Optional":        {},
-	"Security":                  {},
-	"Storage":                   {},
-	"Streaming & Messaging":     {},
+	"AI/Machine Learning":         {},
+	"Application Runtime":         {},
+	"Big Data":                    {},
+	"Cloud Provider":              {},
+	"Developer Tools":             {},
+	"Database":                    {},
+	"Integration & Delivery":      {},
+	"Logging & Tracing":           {},
+	"Migration and Modernization": {},
+	"Modernization & Migration":   {},
+	"Monitoring":                  {},
+	"Networking":                  {},
+	"OpenShift Optional":          {},
+	"Security":                    {},
+	"Storage":                     {},
+	"Streaming & Messaging":       {},
 }
 
 const minKubeVersionWarnMessage = "csv.Spec.minKubeVersion is not informed. It is recommended you provide this information. " +


### PR DESCRIPTION
The intention is to rename 'Modernization & Migration' (M & M) category
to 'Migration and Modernization' (M and M).  The approach we're taking
is to first introduce 'M and M' alongside 'M & M', then reach out to
existing consumers of the 'M & M' category to switch to the 'M and M'
category, followed by later removing 'M & M' as a category.

Reference(s):
- https://issues.redhat.com/browse/MIG-980
- https://issues.redhat.com/browse/MIG-978
- https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/732
- https://github.com/k8s-operatorhub/community-operators/issues/475
- https://github.com/operator-framework/community-operators/pull/2760
- https://github.com/operator-framework/community-operators/pull/2961

Signed-off-by: Rayford Johnson <rayfordj@users.noreply.github.com>