### PR TITLE
bundle size validator: fix and improvements

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -48,4 +48,4 @@ jobs:
       with:
         fetch-depth: 0
     - name: Run go-apidiff
-      uses: joelanford/go-apidiff@master
+      uses: joelanford/go-apidiff@main

--- a/pkg/manifests/bundle.go
+++ b/pkg/manifests/bundle.go
@@ -20,7 +20,9 @@ type Bundle struct {
 	V1CRDs         []*apiextensionsv1.CustomResourceDefinition
 	Dependencies   []*Dependency
 	// CompressedSize stores the gzip size of the bundle
-	CompressedSize *int64
+	CompressedSize int64
+	// Size stores the size of the bundle
+	Size int64
 }
 
 func (b *Bundle) ObjectsToValidate() []interface{} {


### PR DESCRIPTION
- fix: bundle size validator: amount compressed scenarios should be lower than < ~1MB **(required and blocks SDK release 1.18.0)**
- add total uncompressed info and add unit format method to have a better output to help the users 
