### PR TITLE
feat: add warn for bundles size < ~1MB

### DIFF
--- a/pkg/validation/internal/bundle.go
+++ b/pkg/validation/internal/bundle.go
@@ -166,6 +166,18 @@ func validateBundleSize(bundle *manifests.Bundle) []errors.Error {
 			bundle.Name))
 	}
 
+	// Before these versions the bundles were not compressed
+	// and their size must be < ~1MB
+	// todo: remove me at 2023
+	if bundle.Size > max_bundle_size {
+		errs = append(errs, errors.WarnInvalidBundle(
+			fmt.Sprintf("bundle uncompressed size exceeded the limit support for OLM versions relesed prior 1.17.5 :  size=~%s , max=%s. "+
+				"(these bundle cannot work in any cluster or vendor which uses OLM versions < 1.17.5 like OpenShift versions < 4.9)",
+				formatBytesInUnit(bundle.Size),
+				formatBytesInUnit(max_bundle_size)),
+			bundle.Name))
+	}
+
 	return errs
 }
 

--- a/pkg/validation/internal/bundle_test.go
+++ b/pkg/validation/internal/bundle_test.go
@@ -192,6 +192,7 @@ func TestBundleSize(t *testing.T) {
 			wantWarning: true,
 			warnStrings: []string{
 				"Warning: Value : nearing maximum bundle compressed size with gzip: size=~948.6 kB , max=1.0 MB. Bundle uncompressed size is 9.5 MB",
+				"Warning: Value : bundle uncompressed size exceeded the limit support for OLM versions relesed prior 1.17.5 :  size=~9.5 MB , max=1.0 MB. (these bundle cannot work in any cluster or vendor which uses OLM versions < 1.17.5 like OpenShift versions < 4.9)",
 			},
 		},
 		{
@@ -216,9 +217,13 @@ func TestBundleSize(t *testing.T) {
 				sizeCompressed: 2 * max_bundle_size,
 				size:           (2 * max_bundle_size) * 10,
 			},
-			wantError: true,
+			wantError:   true,
+			wantWarning: true,
 			errStrings: []string{
 				"Error: Value : maximum bundle compressed size with gzip size exceeded: size=~2.1 MB , max=1.0 MB. Bundle uncompressed size is 21.0 MB",
+			},
+			warnStrings: []string{
+				"Warning: Value : bundle uncompressed size exceeded the limit support for OLM versions relesed prior 1.17.5 :  size=~21.0 MB , max=1.0 MB. (these bundle cannot work in any cluster or vendor which uses OLM versions < 1.17.5 like OpenShift versions < 4.9)",
 			},
 		},
 	}

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -25,6 +25,25 @@ var ClusterServiceVersionValidator = internal.CSVValidator
 var CustomResourceDefinitionValidator = internal.CRDValidator
 
 // BundleValidator implements Validator to validate Bundles.
+//
+// This check will verify if the Bundle spec is valid by checking:
+//
+// - for duplicate keys in the bundle, which may occur if a v1 and v1beta1 CRD of the same GVK appear.
+//
+// - if owned keys must matches with a CRD in bundle
+//
+// - if the bundle has APIs(CRDs) which are not defined in the CSV
+//
+// - if the bundle size compressed is < ~1MB
+//
+// NOTE: The bundle size test will raise an error if the size is bigger than the max allowed
+// and warnings when:
+// a) the api is unable to check the bundle size because we are running a check without load the bundle
+//
+// b) the api could identify that the bundle size is close to the limit (bigger than 85%)
+//
+// c) [Deprecated and planned to be removed at 2023 -  The API will start growing to encompass validation for all past history] - if the bundle size uncompressed < ~1MB and it cannot work on clusters which uses OLM versions < 1.17.5
+//
 var BundleValidator = internal.BundleValidator
 
 // OperatorHubValidator implements Validator to validate bundle objects


### PR DESCRIPTION
**Description**

Add warning to let operator authors be aware that their bundle will not work on previous versions because are < ~1MB.

**Why?**

It has changed recently and authors who publish in OperatorHub as any other index can be aware that bundles > ~1MB does not work in the old versions. However, we can plan to remove this validation/warn in some timeframe like 1 yr. 

**Motivations**

- Authors be aware that their bundle can work only if it will be published/distributed in OLM > = 1.17.5 (OCP > 4.9). That shows very important info for who publishes in OperatorHub.io
-  CI ( e.g. CVP reports): Help us easily identify why the deployment tests fail. The warning will appear in the report and reduce our effort in troubleshooting these scenarios. 
- For operator authors: help identify and avoid scenarios like: https://bugzilla.redhat.com/show_bug.cgi?id=2054514 or any scenario where they are not aware that their bundle cannot work on this versions which will be still in use for a while. 
- Give the ability for pipelines to use these warn if they are unable to test the bundle against all versions where it will be deployed. For e.g. we have pipelines that are testing only in the upper OLM version where the bundle will be distributed because of the high cost to test against a big matrix. 
- Audit: Give the ability to verify how many use cases we have published in the index and are not working at all because the bundle is > 1MB and these indexes are used with OLM versions <  1.17.5 (OCP < 4.9)
