### PR TITLE
Refactor removed_api_tests to tests against sorted strings to avoid flakiness

### DIFF
--- a/pkg/validation/internal/removed_apis_test.go
+++ b/pkg/validation/internal/removed_apis_test.go
@@ -1,11 +1,10 @@
 package internal
 
 import (
-	"reflect"
-	"testing"
-
 	"github.com/operator-framework/api/pkg/manifests"
 	"github.com/stretchr/testify/require"
+	"reflect"
+	"testing"
 )
 
 func Test_GetRemovedAPIsOn1_22From(t *testing.T) {


### PR DESCRIPTION
There seems to be some flakiness on the order of the APIs. E.g.

```
        removed_apis_test.go:286: 
            	Error Trace:	removed_apis_test.go:286
            	Error:      	[]string{"this bundle is using APIs which were deprecated and removed in v1.25. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-25. Migrate the API(s) for HorizontalPodAutoscaler: ([\"memcached-operator-hpa\"]),PodDisruptionBudget: ([\"memcached-operator-policy-manager\"]),"} does not contain "this bundle is using APIs which were deprecated and removed in v1.25. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-25. Migrate the API(s) for PodDisruptionBudget: ([\"memcached-operator-policy-manager\"]),HorizontalPodAutoscaler: ([\"memcached-operator-hpa\"]),"
            	Test:       	TestValidateDeprecatedAPIS/should_return_a_warning_if_the_k8sVersion_is_empty_and_found_removed_APIs_on_1.25
```

from [here](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_operator-framework-olm/318/pull-ci-openshift-operator-framework-olm-master-unit-api/1538797369888346112#1:build-log.txt%3A142)