### PR TITLE
*: Introduce golangci-lint into the repository

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -19,3 +19,22 @@ jobs:
         run: |
           export GOPATH=$(go env GOPATH)
           make verify
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '~1.19'
+      - name: Cache build and module paths
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Run golangci linting checks
+        run: make lint

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,49 @@
+run:
+  # Default timeout is 1m, up to give more room
+  timeout: 5m
+  skip-dirs:
+  - crds
+
+linters:
+  enable:
+  - asciicheck
+  - depguard
+  - gofmt
+  - goimports
+  - importas
+  - revive
+  - misspell
+  - stylecheck
+  - tparallel
+  - unconvert
+  - whitespace
+  disable:
+  - unused
+
+linters-settings:
+  importas:
+    alias:
+    - pkg: k8s.io/api/core/v1
+      alias: corev1
+    - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+      alias: metav1
+    - pkg: k8s.io/apimachinery/pkg/api/errors
+      alias: apierrors
+    - pkg: github.com/operator-framework/api/pkg/operators/v1alpha1
+      alias: operatorsv1alpha1
+    - pkg: github.com/operator-framework/api/pkg/operators/v1
+      alias: operatorsv1
+  revive:
+    rules:
+    - name: dot-imports
+      severity: warning
+      disabled: true
+  stylecheck:
+    dot-import-whitelist:
+      - github.com/onsi/gomega
+      - github.com/onsi/ginkgo
+  goimports:
+    local-prefixes: github.com/operator-framework/api
+
+output:
+  format: tab

--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,10 @@ install: ## Build & install operator-verify
 ###
 # Code management.
 ###
-.PHONY: format tidy clean generate manifests
+.PHONY: lint tidy clean generate manifests
 
-format: ## Format the source code
-	$(Q)go fmt $(PKGS)
+lint: golangci-lint ## Run golangci-lint linter checks.
+	$(GOLANGCI_LINT) run
 
 tidy: ## Update dependencies
 	$(Q)go mod tidy
@@ -82,7 +82,7 @@ TEST_PKGS:=$(shell go list ./...)
 test-unit: ## Run the unit tests
 	$(Q)go test -count=1 -short ${TEST_PKGS}
 
-verify: manifests generate format
+verify: manifests generate
 	git diff --exit-code
 
 ################
@@ -99,10 +99,12 @@ $(LOCALBIN):
 ## Tool Binaries
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 YQ ?= $(LOCALBIN)/yq
+GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
 CONTROLLER_TOOLS_VERSION ?= v0.9.0
 YQ_VERSION ?= latest
+GOLANGCI_LINT_VERSION ?= v1.49.0
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
@@ -113,3 +115,8 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 yq: $(YQ) ## Download yq locally if necessary.
 $(YQ): $(LOCALBIN)
 	GOBIN=$(LOCALBIN) go install $(GO_INSTALL_OPTS) github.com/mikefarah/yq/v3@$(YQ_VERSION)
+
+.PHONY: golangci-lint
+golangci-lint: $(GOLANGCI_LINT)
+$(GOLANGCI_LINT): $(LOCALBIN) ## Download golangci-lint locally if necessary.
+	GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)

--- a/cmd/operator-verify/manifests/cmd.go
+++ b/cmd/operator-verify/manifests/cmd.go
@@ -70,6 +70,4 @@ func manifestsFunc(cmd *cobra.Command, args []string) {
 			log.Warnf(err.Error())
 		}
 	}
-
-	return
 }

--- a/pkg/constraints/cel.go
+++ b/pkg/constraints/cel.go
@@ -29,8 +29,8 @@ func NewCelEnvironment() *CelEnvironment {
 		decls.NewVar(PropertiesKey, decls.NewListType(decls.NewMapType(decls.String, decls.Any)))),
 		cel.Lib(semverLib{}),
 	)
-	// If an error occurs here, it means the CEL enviroment is unable to load
-	// configuration for custom libraries propertly. Hence, the CEL enviroment is
+	// If an error occurs here, it means the CEL environment is unable to load
+	// configuration for custom libraries property. Hence, the CEL environment is
 	// unusable. Panic here will cause the program to fail immediately to prevent
 	// cascading failures later on when this CEL env is in use.
 	if err != nil {
@@ -41,7 +41,7 @@ func NewCelEnvironment() *CelEnvironment {
 	}
 }
 
-// CelEnvironment is a struct that encapsulates CEL custom program enviroment
+// CelEnvironment is a struct that encapsulates CEL custom program environment
 type CelEnvironment struct {
 	env *cel.Env
 }
@@ -63,7 +63,7 @@ Example:
 
 The result is `semver_compare` is an integer just like `Compare`. So, the CEL
 expression `semver_compare(v1, v2) == 0` is equivalent v1.Compare(v2) == 0. In
-the other words, it checks if v1 is equal to v2 in term of semver comparision.
+the other words, it checks if v1 is equal to v2 in term of semver comparison.
 */
 type semverLib struct{}
 

--- a/pkg/lib/version/version.go
+++ b/pkg/lib/version/version.go
@@ -45,9 +45,7 @@ func (v *OperatorVersion) UnmarshalJSON(data []byte) (err error) {
 	if err = json.Unmarshal(data, &versionString); err != nil {
 		return
 	}
-
-	version := semver.Version{}
-	version, err = semver.ParseTolerant(versionString)
+	version, err := semver.ParseTolerant(versionString)
 	if err != nil {
 		return err
 	}
@@ -59,9 +57,9 @@ func (v *OperatorVersion) UnmarshalJSON(data []byte) (err error) {
 // the OpenAPI spec of this type.
 //
 // See: https://github.com/kubernetes/kube-openapi/tree/master/pkg/generators
-func (_ OperatorVersion) OpenAPISchemaType() []string { return []string{"string"} }
+func (OperatorVersion) OpenAPISchemaType() []string { return []string{"string"} }
 
 // OpenAPISchemaFormat is used by the kube-openapi generator when constructing
 // the OpenAPI spec of this type.
 // "semver" is not a standard openapi format but tooling may use the value regardless
-func (_ OperatorVersion) OpenAPISchemaFormat() string { return "semver" }
+func (OperatorVersion) OpenAPISchemaFormat() string { return "semver" }

--- a/pkg/manifests/bundleloader.go
+++ b/pkg/manifests/bundleloader.go
@@ -2,7 +2,6 @@ package manifests
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -180,7 +179,7 @@ func (b *bundleLoader) LoadBundleWalkFunc(path string, f os.FileInfo, err error)
 // loadBundle takes the directory that a CSV is in and assumes the rest of the objects in that directory
 // are part of the bundle.
 func loadBundle(csvName string, dir string) (*Bundle, error) {
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/manifests/directory.go
+++ b/pkg/manifests/directory.go
@@ -12,7 +12,7 @@ func GetManifestsDir(dir string) (*PackageManifest, []*Bundle, error) {
 	return loader.pkg, loader.bundles, nil
 }
 
-// GetBundleFromDir takes a raw directory containg an Operator Bundle and
+// GetBundleFromDir takes a raw directory containing an Operator Bundle and
 // serializes its component files (CSVs, CRDs, other native kube manifests)
 // and returns it as a Bundle
 func GetBundleFromDir(dir string) (*Bundle, error) {

--- a/pkg/operators/reference/reference_test.go
+++ b/pkg/operators/reference/reference_test.go
@@ -10,8 +10,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 
-	v1 "github.com/operator-framework/api/pkg/operators/v1"
-	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 )
 
 func TestGetReference(t *testing.T) {
@@ -38,12 +38,12 @@ func TestGetReference(t *testing.T) {
 		{
 			name: "v1alpha1/ClusterServiceVersion",
 			args: args{
-				&v1alpha1.ClusterServiceVersion{
+				&operatorsv1alpha1.ClusterServiceVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "ns",
 						Name:      "csv",
 						UID:       types.UID("uid"),
-						SelfLink:  buildSelfLink(v1alpha1.SchemeGroupVersion.String(), "clusterserviceversions", "ns", "csv"),
+						SelfLink:  buildSelfLink(operatorsv1alpha1.SchemeGroupVersion.String(), "clusterserviceversions", "ns", "csv"),
 					},
 				},
 			},
@@ -52,8 +52,8 @@ func TestGetReference(t *testing.T) {
 					Namespace:  "ns",
 					Name:       "csv",
 					UID:        types.UID("uid"),
-					Kind:       v1alpha1.ClusterServiceVersionKind,
-					APIVersion: v1alpha1.SchemeGroupVersion.String(),
+					Kind:       operatorsv1alpha1.ClusterServiceVersionKind,
+					APIVersion: operatorsv1alpha1.SchemeGroupVersion.String(),
 				},
 				err: nil,
 			},
@@ -61,12 +61,12 @@ func TestGetReference(t *testing.T) {
 		{
 			name: "v1alpha1/InstallPlan",
 			args: args{
-				&v1alpha1.InstallPlan{
+				&operatorsv1alpha1.InstallPlan{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "ns",
 						Name:      "ip",
 						UID:       types.UID("uid"),
-						SelfLink:  buildSelfLink(v1alpha1.SchemeGroupVersion.String(), "installplans", "ns", "ip"),
+						SelfLink:  buildSelfLink(operatorsv1alpha1.SchemeGroupVersion.String(), "installplans", "ns", "ip"),
 					},
 				},
 			},
@@ -75,8 +75,8 @@ func TestGetReference(t *testing.T) {
 					Namespace:  "ns",
 					Name:       "ip",
 					UID:        types.UID("uid"),
-					Kind:       v1alpha1.InstallPlanKind,
-					APIVersion: v1alpha1.SchemeGroupVersion.String(),
+					Kind:       operatorsv1alpha1.InstallPlanKind,
+					APIVersion: operatorsv1alpha1.SchemeGroupVersion.String(),
 				},
 				err: nil,
 			},
@@ -84,12 +84,12 @@ func TestGetReference(t *testing.T) {
 		{
 			name: "v1alpha1/Subscription",
 			args: args{
-				&v1alpha1.Subscription{
+				&operatorsv1alpha1.Subscription{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "ns",
 						Name:      "sub",
 						UID:       types.UID("uid"),
-						SelfLink:  buildSelfLink(v1alpha1.SchemeGroupVersion.String(), "subscriptions", "ns", "sub"),
+						SelfLink:  buildSelfLink(operatorsv1alpha1.SchemeGroupVersion.String(), "subscriptions", "ns", "sub"),
 					},
 				},
 			},
@@ -98,8 +98,8 @@ func TestGetReference(t *testing.T) {
 					Namespace:  "ns",
 					Name:       "sub",
 					UID:        types.UID("uid"),
-					Kind:       v1alpha1.SubscriptionKind,
-					APIVersion: v1alpha1.SchemeGroupVersion.String(),
+					Kind:       operatorsv1alpha1.SubscriptionKind,
+					APIVersion: operatorsv1alpha1.SchemeGroupVersion.String(),
 				},
 				err: nil,
 			},
@@ -107,12 +107,12 @@ func TestGetReference(t *testing.T) {
 		{
 			name: "v1alpha1/CatalogSource",
 			args: args{
-				&v1alpha1.CatalogSource{
+				&operatorsv1alpha1.CatalogSource{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "ns",
 						Name:      "catsrc",
 						UID:       types.UID("uid"),
-						SelfLink:  buildSelfLink(v1alpha1.SchemeGroupVersion.String(), "catalogsources", "ns", "catsrc"),
+						SelfLink:  buildSelfLink(operatorsv1alpha1.SchemeGroupVersion.String(), "catalogsources", "ns", "catsrc"),
 					},
 				},
 			},
@@ -121,8 +121,8 @@ func TestGetReference(t *testing.T) {
 					Namespace:  "ns",
 					Name:       "catsrc",
 					UID:        types.UID("uid"),
-					Kind:       v1alpha1.CatalogSourceKind,
-					APIVersion: v1alpha1.SchemeGroupVersion.String(),
+					Kind:       operatorsv1alpha1.CatalogSourceKind,
+					APIVersion: operatorsv1alpha1.SchemeGroupVersion.String(),
 				},
 				err: nil,
 			},
@@ -130,12 +130,12 @@ func TestGetReference(t *testing.T) {
 		{
 			name: "v1/OperatorGroup",
 			args: args{
-				&v1.OperatorGroup{
+				&operatorsv1.OperatorGroup{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "ns",
 						Name:      "og",
 						UID:       types.UID("uid"),
-						SelfLink:  buildSelfLink(v1.SchemeGroupVersion.String(), "operatorgroups", "ns", "og"),
+						SelfLink:  buildSelfLink(operatorsv1.SchemeGroupVersion.String(), "operatorgroups", "ns", "og"),
 					},
 				},
 			},
@@ -144,8 +144,8 @@ func TestGetReference(t *testing.T) {
 					Namespace:  "ns",
 					Name:       "og",
 					UID:        types.UID("uid"),
-					Kind:       v1.OperatorGroupKind,
-					APIVersion: v1.SchemeGroupVersion.String(),
+					Kind:       operatorsv1.OperatorGroupKind,
+					APIVersion: operatorsv1.SchemeGroupVersion.String(),
 				},
 				err: nil,
 			},

--- a/pkg/operators/v1/operatorgroup_types.go
+++ b/pkg/operators/v1/operatorgroup_types.go
@@ -156,11 +156,7 @@ func (o *OperatorGroup) UpgradeStrategy() UpgradeStrategy {
 
 // IsServiceAccountSpecified returns true if the spec has a service account name specified.
 func (o *OperatorGroup) IsServiceAccountSpecified() bool {
-	if o.Spec.ServiceAccountName == "" {
-		return false
-	}
-
-	return true
+	return o.Spec.ServiceAccountName != ""
 }
 
 // HasServiceAccountSynced returns true if the service account specified has been synced.
@@ -176,7 +172,7 @@ func (o *OperatorGroup) HasServiceAccountSynced() bool {
 // If the UID is not set an error is returned.
 func (o *OperatorGroup) OGLabelKeyAndValue() (string, string, error) {
 	if string(o.GetUID()) == "" {
-		return "", "", fmt.Errorf("Missing UID")
+		return "", "", fmt.Errorf("missing UID")
 	}
 	return fmt.Sprintf(OperatorGroupLabelTemplate, o.GetUID()), "", nil
 }

--- a/pkg/operators/v1alpha1/clusterserviceversion.go
+++ b/pkg/operators/v1alpha1/clusterserviceversion.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 )
@@ -62,9 +62,9 @@ func (c *ClusterServiceVersion) SetPhaseWithEventIfChanged(phase ClusterServiceV
 func (c *ClusterServiceVersion) SetPhaseWithEvent(phase ClusterServiceVersionPhase, reason ConditionReason, message string, now *metav1.Time, recorder record.EventRecorder) {
 	var eventtype string
 	if phase == CSVPhaseFailed {
-		eventtype = v1.EventTypeWarning
+		eventtype = corev1.EventTypeWarning
 	} else {
-		eventtype = v1.EventTypeNormal
+		eventtype = corev1.EventTypeNormal
 	}
 	go recorder.Event(c, eventtype, string(reason), message)
 	c.SetPhase(phase, reason, message, now)
@@ -173,7 +173,7 @@ func (set InstallModeSet) Supports(operatorNamespace string, namespaces []string
 			if !set[InstallModeTypeOwnNamespace] {
 				return fmt.Errorf("%s InstallModeType not supported, cannot configure to watch own namespace", InstallModeTypeOwnNamespace)
 			}
-		case v1.NamespaceAll:
+		case corev1.NamespaceAll:
 			if !set[InstallModeTypeAllNamespaces] {
 				return fmt.Errorf("%s InstallModeType not supported, cannot configure to watch all namespaces", InstallModeTypeAllNamespaces)
 			}
@@ -189,7 +189,7 @@ func (set InstallModeSet) Supports(operatorNamespace string, namespaces []string
 			if namespace == operatorNamespace && !set[InstallModeTypeOwnNamespace] {
 				return fmt.Errorf("%s InstallModeType not supported, cannot configure to watch own namespace", InstallModeTypeOwnNamespace)
 			}
-			if namespace == v1.NamespaceAll {
+			if namespace == corev1.NamespaceAll {
 				return fmt.Errorf("operatorgroup has invalid selected namespaces, NamespaceAll found when |selected namespaces| > 1")
 			}
 		}

--- a/pkg/operators/v1alpha1/clusterserviceversion_test.go
+++ b/pkg/operators/v1alpha1/clusterserviceversion_test.go
@@ -4,12 +4,11 @@ import (
 	"fmt"
 	"testing"
 
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestSetRequirementStatus(t *testing.T) {
@@ -379,7 +378,7 @@ func TestWebhookDescGetValidatingConfigurations(t *testing.T) {
 		TimeoutSeconds:          &timeout,
 		WebhookPath:             &webhookPath,
 		Rules: []admissionregistrationv1.RuleWithOperations{
-			admissionregistrationv1.RuleWithOperations{
+			{
 				Operations: []admissionregistrationv1.OperationType{},
 				Rule: admissionregistrationv1.Rule{
 					APIGroups:   []string{"*"},

--- a/pkg/operators/v1alpha1/clusterserviceversion_types.go
+++ b/pkg/operators/v1alpha1/clusterserviceversion_types.go
@@ -419,12 +419,8 @@ const (
 )
 
 // HasCaResources returns true if the CSV has owned APIServices or Webhooks.
-func (c *ClusterServiceVersion) HasCAResources() bool {
-	// Return early if there are no owned APIServices
-	if len(c.Spec.APIServiceDefinitions.Owned)+len(c.Spec.WebhookDefinitions) == 0 {
-		return false
-	}
-	return true
+func (csv *ClusterServiceVersion) HasCAResources() bool {
+	return len(csv.Spec.APIServiceDefinitions.Owned)+len(csv.Spec.WebhookDefinitions) != 0
 }
 
 // Conditions appear in the status as a record of state transitions on the ClusterServiceVersion
@@ -669,9 +665,7 @@ func (csv ClusterServiceVersion) GetRequiredAPIServiceDescriptions() []APIServic
 	// Remove any shared owned from the set
 	for _, owned := range csv.Spec.APIServiceDefinitions.Owned {
 		name := fmt.Sprintf("%s.%s", owned.Version, owned.Group)
-		if _, ok := set[name]; ok {
-			delete(set, name)
-		}
+		delete(set, name)
 	}
 
 	keys := make([]string, 0)

--- a/pkg/operators/v1alpha1/installplan_types.go
+++ b/pkg/operators/v1alpha1/installplan_types.go
@@ -119,9 +119,6 @@ type InstallPlanCondition struct {
 	Message            string                     `json:"message,omitempty"`
 }
 
-// allow overwriting `now` function for deterministic tests
-var now = metav1.Now
-
 // GetCondition returns the InstallPlanCondition of the given type if it exists in the InstallPlanStatus' Conditions.
 // Returns a condition of the given type with a ConditionStatus of "Unknown" if not found.
 func (s InstallPlanStatus) GetCondition(conditionType InstallPlanConditionType) InstallPlanCondition {

--- a/pkg/operators/v1alpha1/register.go
+++ b/pkg/operators/v1alpha1/register.go
@@ -33,9 +33,6 @@ var (
 	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 	// AddToScheme is a global function that registers this API group & version to a scheme
 	AddToScheme = SchemeBuilder.AddToScheme
-
-	// localSchemeBuilder is expected by generated conversion functions
-	localSchemeBuilder = &SchemeBuilder
 )
 
 // addKnownTypes adds the list of known types to Scheme

--- a/pkg/operators/v1alpha1/subscription_types.go
+++ b/pkg/operators/v1alpha1/subscription_types.go
@@ -282,7 +282,7 @@ type SubscriptionCatalogHealth struct {
 }
 
 // Equals returns true if a SubscriptionCatalogHealth equals the one given, false otherwise.
-// Equality is based SOLEY on health and UID.
+// Equality is based SOLELY on health and UID.
 func (s SubscriptionCatalogHealth) Equals(health SubscriptionCatalogHealth) bool {
 	return s.Healthy == health.Healthy && s.CatalogSourceRef.UID == health.CatalogSourceRef.UID
 }

--- a/pkg/operators/v1alpha2/operatorgroup_types.go
+++ b/pkg/operators/v1alpha2/operatorgroup_types.go
@@ -82,11 +82,7 @@ func (o *OperatorGroup) BuildTargetNamespaces() string {
 
 // IsServiceAccountSpecified returns true if the spec has a service account name specified.
 func (o *OperatorGroup) IsServiceAccountSpecified() bool {
-	if o.Spec.ServiceAccountName == "" {
-		return false
-	}
-
-	return true
+	return o.Spec.ServiceAccountName != ""
 }
 
 // HasServiceAccountSynced returns true if the service account specified has been synced.

--- a/pkg/validation/internal/annotations.go
+++ b/pkg/validation/internal/annotations.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	v1 "github.com/operator-framework/api/pkg/operators/v1"
-	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/api/pkg/validation/errors"
 )
 
@@ -16,11 +16,11 @@ const olmpropertiesAnnotation = "olm.properties"
 // contains the expected case sensitive string. This may not be an exhaustive list.
 var CaseSensitiveAnnotationKeySet = map[string]string{
 
-	strings.ToLower(v1.OperatorGroupAnnotationKey):             v1.OperatorGroupAnnotationKey,
-	strings.ToLower(v1.OperatorGroupNamespaceAnnotationKey):    v1.OperatorGroupNamespaceAnnotationKey,
-	strings.ToLower(v1.OperatorGroupTargetsAnnotationKey):      v1.OperatorGroupTargetsAnnotationKey,
-	strings.ToLower(v1.OperatorGroupProvidedAPIsAnnotationKey): v1.OperatorGroupProvidedAPIsAnnotationKey,
-	strings.ToLower(v1alpha1.SkipRangeAnnotationKey):           v1alpha1.SkipRangeAnnotationKey,
+	strings.ToLower(operatorsv1.OperatorGroupAnnotationKey):             operatorsv1.OperatorGroupAnnotationKey,
+	strings.ToLower(operatorsv1.OperatorGroupNamespaceAnnotationKey):    operatorsv1.OperatorGroupNamespaceAnnotationKey,
+	strings.ToLower(operatorsv1.OperatorGroupTargetsAnnotationKey):      operatorsv1.OperatorGroupTargetsAnnotationKey,
+	strings.ToLower(operatorsv1.OperatorGroupProvidedAPIsAnnotationKey): operatorsv1.OperatorGroupProvidedAPIsAnnotationKey,
+	strings.ToLower(operatorsv1alpha1.SkipRangeAnnotationKey):           operatorsv1alpha1.SkipRangeAnnotationKey,
 }
 
 /*

--- a/pkg/validation/internal/bundle_test.go
+++ b/pkg/validation/internal/bundle_test.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/operator-framework/api/pkg/manifests"
-	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/api/pkg/validation/errors"
 )
 
@@ -75,9 +75,9 @@ func TestValidateBundle(t *testing.T) {
 }
 
 func TestValidateServiceAccount(t *testing.T) {
-	csvWithSAs := func(saNames ...string) *v1alpha1.ClusterServiceVersion {
-		csv := &v1alpha1.ClusterServiceVersion{}
-		depSpecs := make([]v1alpha1.StrategyDeploymentSpec, len(saNames))
+	csvWithSAs := func(saNames ...string) *operatorsv1alpha1.ClusterServiceVersion {
+		csv := &operatorsv1alpha1.ClusterServiceVersion{}
+		depSpecs := make([]operatorsv1alpha1.StrategyDeploymentSpec, len(saNames))
 		for i, saName := range saNames {
 			depSpecs[i].Spec.Template.Spec.ServiceAccountName = saName
 		}
@@ -179,15 +179,15 @@ func TestBundleSize(t *testing.T) {
 		{
 			name: "should pass when the size is not bigger or closer of the limit",
 			args: args{
-				sizeCompressed: max_bundle_size / 2,
-				size:           max_bundle_size / 2,
+				sizeCompressed: maxBundleSize / 2,
+				size:           maxBundleSize / 2,
 			},
 		},
 		{
 			name: "should warn when the size is closer of the limit",
 			args: args{
-				sizeCompressed: max_bundle_size - 100000,
-				size:           (max_bundle_size - 100000) * 10,
+				sizeCompressed: maxBundleSize - 100000,
+				size:           (maxBundleSize - 100000) * 10,
 			},
 			wantWarning: true,
 			warnStrings: []string{
@@ -197,7 +197,7 @@ func TestBundleSize(t *testing.T) {
 		{
 			name: "should warn when is not possible to check the size compressed",
 			args: args{
-				size: max_bundle_size * 1024,
+				size: maxBundleSize * 1024,
 			},
 			wantWarning: true,
 			warnStrings: []string{"Warning: Value : unable to check the bundle compressed size"},
@@ -205,7 +205,7 @@ func TestBundleSize(t *testing.T) {
 		{
 			name: "should warn when is not possible to check the size",
 			args: args{
-				sizeCompressed: max_bundle_size / 2,
+				sizeCompressed: maxBundleSize / 2,
 			},
 			wantWarning: true,
 			warnStrings: []string{"Warning: Value : unable to check the bundle size"},
@@ -213,8 +213,8 @@ func TestBundleSize(t *testing.T) {
 		{
 			name: "should raise an error when the size is bigger than the limit",
 			args: args{
-				sizeCompressed: 2 * max_bundle_size,
-				size:           (2 * max_bundle_size) * 10,
+				sizeCompressed: 2 * maxBundleSize,
+				size:           (2 * maxBundleSize) * 10,
 			},
 			wantError: true,
 			errStrings: []string{
@@ -281,7 +281,6 @@ func Test_EnsureGetBundleSizeValue(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			// Validate the bundle object
 			bundle, err := manifests.GetBundleFromDir(tt.args.bundleDir)
 			require.NoError(t, err)

--- a/pkg/validation/internal/community.go
+++ b/pkg/validation/internal/community.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -38,7 +37,6 @@ const ocpVerV1beta1Unsupported = "4.9"
 var CommunityOperatorValidator interfaces.Validator = interfaces.ValidatorFunc(communityValidator)
 
 func communityValidator(objs ...interface{}) (results []errors.ManifestResult) {
-
 	// Obtain the k8s version if informed via the objects an optional
 	var indexImagePath = ""
 	for _, obj := range objs {
@@ -68,14 +66,13 @@ type CommunityOperatorChecks struct {
 	warns          []error
 }
 
-// validateCommunityBundle will check the bundle against the community-operator criterias
+// validateCommunityBundle will check the bundle against the community-operator criteria.
 func validateCommunityBundle(bundle *manifests.Bundle, indexImagePath string) errors.ManifestResult {
-	result := errors.ManifestResult{Name: bundle.Name}
 	if bundle == nil {
-		result.Add(errors.ErrInvalidBundle("Bundle is nil", nil))
-		return result
+		return errors.ManifestResult{Errors: []errors.Error{errors.ErrInvalidBundle("Bundle is nil", nil)}}
 	}
 
+	result := errors.ManifestResult{Name: bundle.Name}
 	if bundle.CSV == nil {
 		result.Add(errors.ErrInvalidBundle("Bundle csv is nil", bundle.Name))
 		return result
@@ -225,7 +222,7 @@ func validateImageFile(checks CommunityOperatorChecks, deprecatedAPImsg string) 
 		return checks
 	}
 
-	b, err := ioutil.ReadFile(checks.indexImagePath)
+	b, err := os.ReadFile(checks.indexImagePath)
 	if err != nil {
 		checks.errs = append(checks.errs, fmt.Errorf("unable to read the index image in the path "+
 			"(%s). Error : %s", checks.indexImagePath, err))

--- a/pkg/validation/internal/community_test.go
+++ b/pkg/validation/internal/community_test.go
@@ -1,10 +1,11 @@
 package internal
 
 import (
-	"fmt"
-	"github.com/operator-framework/api/pkg/manifests"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/operator-framework/api/pkg/manifests"
 )
 
 func Test_communityValidator(t *testing.T) {
@@ -36,7 +37,7 @@ func Test_communityValidator(t *testing.T) {
 				bundleDir:      "./testdata/valid_bundle_v1beta1",
 				imageIndexPath: "./testdata/dockerfile/valid_bundle.Dockerfile",
 				annotations: map[string]string{
-					"olm.properties": fmt.Sprintf(`[{"type": "olm.maxOpenShiftVersion", "value": "4.8"}]`),
+					"olm.properties": `[{"type": "olm.maxOpenShiftVersion", "value": "4.8"}]`,
 				},
 			},
 		},
@@ -63,7 +64,7 @@ func Test_communityValidator(t *testing.T) {
 				bundleDir:      "./testdata/valid_bundle_v1beta1",
 				imageIndexPath: "./testdata/dockerfile/valid_bundle.Dockerfile",
 				annotations: map[string]string{
-					"olm.properties": fmt.Sprintf(`[{"type": "olm.invalid", "value": "4.9"}]`),
+					"olm.properties": `[{"type": "olm.invalid", "value": "4.9"}]`,
 				},
 			},
 			errStrings: []string{"Error: Value : (etcdoperator.v0.9.4) csv.Annotations.olm.properties with the key " +
@@ -79,7 +80,7 @@ func Test_communityValidator(t *testing.T) {
 				bundleDir:      "./testdata/valid_bundle_v1beta1",
 				imageIndexPath: "./testdata/dockerfile/valid_bundle.Dockerfile",
 				annotations: map[string]string{
-					"olm.properties": fmt.Sprintf(`[{"type": "olm.maxOpenShiftVersion", "value": "4.9"}]`),
+					"olm.properties": `[{"type": "olm.maxOpenShiftVersion", "value": "4.9"}]`,
 				},
 			},
 			errStrings: []string{"Error: Value : (etcdoperator.v0.9.4) csv.Annotations.olm.properties with the key " +
@@ -93,7 +94,7 @@ func Test_communityValidator(t *testing.T) {
 			args: args{
 				bundleDir: "./testdata/valid_bundle_v1beta1",
 				annotations: map[string]string{
-					"olm.properties": fmt.Sprintf(`[{"type": "olm.maxOpenShiftVersion", "value": "4.8"}]`),
+					"olm.properties": `[{"type": "olm.maxOpenShiftVersion", "value": "4.8"}]`,
 				},
 			},
 			warnStrings: []string{"Warning: Value : (etcdoperator.v0.9.4) please, inform the path of its index image " +
@@ -111,7 +112,7 @@ func Test_communityValidator(t *testing.T) {
 				bundleDir:      "./testdata/valid_bundle_v1beta1",
 				imageIndexPath: "./testdata/dockerfile/valid_bundle.Dockerfile",
 				annotations: map[string]string{
-					"olm.properties": fmt.Sprintf(`[{"type": "olm.maxOpenShiftVersion", "value": "4.8.1"}]`),
+					"olm.properties": `[{"type": "olm.maxOpenShiftVersion", "value": "4.8.1"}]`,
 				},
 			},
 			warnStrings: []string{
@@ -125,7 +126,7 @@ func Test_communityValidator(t *testing.T) {
 				bundleDir:      "./testdata/valid_bundle_v1beta1",
 				imageIndexPath: "./testdata/dockerfile/valid_bundle.Dockerfile",
 				annotations: map[string]string{
-					"olm.properties": fmt.Sprintf(`[{"type": "olm.maxOpenShiftVersion", "value": "4.8.0+build"}]`),
+					"olm.properties": `[{"type": "olm.maxOpenShiftVersion", "value": "4.8.0+build"}]`,
 				},
 			},
 		},
@@ -137,7 +138,7 @@ func Test_communityValidator(t *testing.T) {
 				bundleDir:      "./testdata/valid_bundle_v1beta1",
 				imageIndexPath: "./testdata/dockerfile/valid_bundle_4_8.Dockerfile",
 				annotations: map[string]string{
-					"olm.properties": fmt.Sprintf(`[{"type": "olm.maxOpenShiftVersion", "value": "4.8"}]`),
+					"olm.properties": `[{"type": "olm.maxOpenShiftVersion", "value": "4.8"}]`,
 				},
 			},
 		},
@@ -145,7 +146,6 @@ func Test_communityValidator(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			// Validate the bundle object
 			bundle, err := manifests.GetBundleFromDir(tt.args.bundleDir)
 			require.NoError(t, err)

--- a/pkg/validation/internal/crd_test.go
+++ b/pkg/validation/internal/crd_test.go
@@ -1,15 +1,15 @@
 package internal
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
-	"github.com/operator-framework/api/pkg/validation/errors"
+	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 
-	"github.com/ghodss/yaml"
+	"github.com/operator-framework/api/pkg/validation/errors"
 )
 
 func TestValidateCRD(t *testing.T) {
@@ -57,12 +57,12 @@ func TestValidateCRD(t *testing.T) {
 		},
 	}
 	for _, tt := range table {
-		b, err := ioutil.ReadFile(tt.filePath)
+		b, err := os.ReadFile(tt.filePath)
 		if err != nil {
 			t.Fatalf("Error reading CRD path %s: %v", tt.filePath, err)
 		}
 
-		results := []errors.ManifestResult{}
+		var results []errors.ManifestResult
 		switch tt.version {
 		case "v1":
 			crd := &v1.CustomResourceDefinition{}

--- a/pkg/validation/internal/csv_test.go
+++ b/pkg/validation/internal/csv_test.go
@@ -2,14 +2,15 @@ package internal
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/ghodss/yaml"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/api/pkg/validation/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func TestValidateCSV(t *testing.T) {
@@ -110,7 +111,7 @@ func TestValidateCSV(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		b, err := ioutil.ReadFile(c.csvPath)
+		b, err := os.ReadFile(c.csvPath)
 		if err != nil {
 			t.Fatalf("Error reading CSV path %s: %v", c.csvPath, err)
 		}

--- a/pkg/validation/internal/good_practices.go
+++ b/pkg/validation/internal/good_practices.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 
 	goerrors "errors"
+
 	"github.com/blang/semver/v4"
 
 	"github.com/operator-framework/api/pkg/manifests"
-	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/api/pkg/validation/errors"
 	interfaces "github.com/operator-framework/api/pkg/validation/interfaces"
@@ -150,7 +150,6 @@ func validateHubChannels(bundle *manifests.Bundle) error {
 			channel != "" {
 			channelsNotFollowingConventional = append(channelsNotFollowingConventional, channel)
 		}
-
 	}
 
 	if len(channelsNotFollowingConventional) > 0 {
@@ -189,7 +188,7 @@ func validateRBACForCRDsWith(csv *operatorsv1alpha1.ClusterServiceVersion) error
 	return nil
 }
 
-func hasRBACFor(perm v1alpha1.StrategyDeploymentPermissions, apiGroupResourceMap map[string][]string, verbs []string) bool {
+func hasRBACFor(perm operatorsv1alpha1.StrategyDeploymentPermissions, apiGroupResourceMap map[string][]string, verbs []string) bool {
 	// For each APIGroup and list of resources that we are looking for
 	for apiFromMap, resourcesFromMap := range apiGroupResourceMap {
 		for _, rule := range perm.Rules {
@@ -229,7 +228,7 @@ func getUniqueValues(array []string) []string {
 		uniqueValues[strings.TrimSpace(n)] = ""
 	}
 
-	for k, _ := range uniqueValues {
+	for k := range uniqueValues {
 		result = append(result, k)
 	}
 	return result

--- a/pkg/validation/internal/good_practices_test.go
+++ b/pkg/validation/internal/good_practices_test.go
@@ -3,10 +3,10 @@ package internal
 import (
 	"testing"
 
-	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/stretchr/testify/require"
 
 	"github.com/operator-framework/api/pkg/manifests"
-	"github.com/stretchr/testify/require"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 )
 
 func Test_ValidateGoodPractices(t *testing.T) {
@@ -157,7 +157,6 @@ func TestValidateHubChannels(t *testing.T) {
 }
 
 func TestValidateRBACForCRDsWith(t *testing.T) {
-
 	bundle, err := manifests.GetBundleFromDir("./testdata/valid_bundle")
 	require.NoError(t, err)
 
@@ -300,7 +299,6 @@ func TestCheckBundleName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			csv := operatorsv1alpha1.ClusterServiceVersion{}
 			csv.Name = tt.args.bundleName
 			result := checkBundleName(&csv)

--- a/pkg/validation/internal/multiarch.go
+++ b/pkg/validation/internal/multiarch.go
@@ -50,9 +50,9 @@ const operatorFrameworkArchLabel = "operatorframework.io/arch."
 // operatorFrameworkOSLabel stores the labels for the supported OS from the CSV
 const operatorFrameworkOSLabel = "operatorframework.io/os."
 
-// default_container_scaffold_by_sdk defines the name of a default scaffold done by SDK
+// defaultContainerScaffoldBySDK defines the name of a default scaffold done by SDK
 // it is useful for we are able to find the operator manager image more assertively
-const default_container_scaffold_by_sdk = "kube-rbac-proxy"
+const defaultContainerScaffoldBySDK = "kube-rbac-proxy"
 
 // multiArchValidator store the data to perform the tests
 type multiArchValidator struct {
@@ -230,7 +230,7 @@ func (data *multiArchValidator) loadImagesFromCSV() {
 		// kube-rbac-proxy image scaffold by default
 		if !foundManager {
 			for _, c := range v.Spec.Template.Spec.Containers {
-				if c.Name != default_container_scaffold_by_sdk && len(data.managerImages[c.Image]) == 0 {
+				if c.Name != defaultContainerScaffoldBySDK && len(data.managerImages[c.Image]) == 0 {
 					data.managerImages[c.Image] = append(data.managerImages[c.Image], platform{})
 					data.managerImagesString = append(data.managerImagesString, c.Image)
 				}
@@ -419,7 +419,6 @@ func (data *multiArchValidator) checkMissingLabelsForSO() {
 			if !(supported == "linux" && len(data.managerOs) == 1 && len(data.managerOs["linux"]) > 0) {
 				notFoundSoLabel = append(notFoundSoLabel, supported)
 			}
-
 		}
 	}
 

--- a/pkg/validation/internal/multiarch_test.go
+++ b/pkg/validation/internal/multiarch_test.go
@@ -1,30 +1,31 @@
 package internal
 
 import (
-	"github.com/operator-framework/api/pkg/manifests"
-	"github.com/operator-framework/api/pkg/operators/v1alpha1"
-	"github.com/stretchr/testify/require"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/operator-framework/api/pkg/manifests"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 )
 
-const opm_test_image = "quay.io/operator-framework/opm:latest"
+const opmTestImage = "quay.io/operator-framework/opm:latest"
 
 func Test_ValidateMultiArchFrom(t *testing.T) {
-
 	// Mock bundle
 	bundleWithoutLabels, _ := manifests.GetBundleFromDir("./testdata/valid_bundle")
 
 	if bundleWithoutLabels.CSV.Spec.InstallStrategy.StrategySpec.DeploymentSpecs != nil {
 		for indexDeployment, v := range bundleWithoutLabels.CSV.Spec.InstallStrategy.StrategySpec.DeploymentSpecs {
-			for indexContainer, _ := range v.Spec.Template.Spec.Containers {
-				bundleWithoutLabels.CSV.Spec.InstallStrategy.StrategySpec.DeploymentSpecs[indexDeployment].Spec.Template.Spec.Containers[indexContainer].Image = opm_test_image
+			for indexContainer := range v.Spec.Template.Spec.Containers {
+				bundleWithoutLabels.CSV.Spec.InstallStrategy.StrategySpec.DeploymentSpecs[indexDeployment].Spec.Template.Spec.Containers[indexContainer].Image = opmTestImage
 			}
 		}
 	}
 
-	for i, _ := range bundleWithoutLabels.CSV.Spec.RelatedImages {
-		bundleWithoutLabels.CSV.Spec.RelatedImages[i].Image = opm_test_image
+	for i := range bundleWithoutLabels.CSV.Spec.RelatedImages {
+		bundleWithoutLabels.CSV.Spec.RelatedImages[i].Image = opmTestImage
 	}
 
 	allLabels := map[string]string{}
@@ -135,7 +136,7 @@ func Test_LoadImagesFromCSV(t *testing.T) {
 
 func Test_LoadImagesFromCSVWithRelatedImage(t *testing.T) {
 	validBundle, _ := manifests.GetBundleFromDir("./testdata/valid_bundle")
-	validBundle.CSV.Spec.RelatedImages = []v1alpha1.RelatedImage{
+	validBundle.CSV.Spec.RelatedImages = []operatorsv1alpha1.RelatedImage{
 		{Image: "related-image-test", Name: "etcd-operator"},
 	}
 
@@ -230,7 +231,7 @@ func Test_RunManifestInspect(t *testing.T) {
 			name: "should return the data from the manifest",
 			args: args{
 				tool:  "docker",
-				image: opm_test_image,
+				image: opmTestImage,
 			},
 			want: manifestInspect{[]manifestData{
 				{platform{Architecture: "amd64", OS: "linux"}},
@@ -419,7 +420,7 @@ func Test_multiArchValidator_checkSupportDefined(t *testing.T) {
 			data.loadImagesFromCSV()
 
 			// Mock inspected platform
-			for key, _ := range data.managerImages {
+			for key := range data.managerImages {
 				data.managerImages[key] = []platform{{"amd64", "linux"}}
 			}
 
@@ -517,7 +518,7 @@ func Test_multiArchValidator_checkMissingLabels(t *testing.T) {
 			data.loadImagesFromCSV()
 
 			// Mock inspected platform
-			for key, _ := range data.managerImages {
+			for key := range data.managerImages {
 				data.managerImages[key] = tt.fields.supportedPlatforms
 			}
 

--- a/pkg/validation/internal/object.go
+++ b/pkg/validation/internal/object.go
@@ -2,13 +2,14 @@ package internal
 
 import (
 	"encoding/json"
-	"github.com/operator-framework/api/pkg/validation/errors"
-	interfaces "github.com/operator-framework/api/pkg/validation/interfaces"
 
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/operator-framework/api/pkg/validation/errors"
+	interfaces "github.com/operator-framework/api/pkg/validation/interfaces"
 )
 
 var ObjectValidator interfaces.Validator = interfaces.ValidatorFunc(validateObjects)

--- a/pkg/validation/internal/object_test.go
+++ b/pkg/validation/internal/object_test.go
@@ -1,10 +1,11 @@
 package internal
 
 import (
-	"github.com/ghodss/yaml"
-	"io/ioutil"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"os"
 	"testing"
+
+	"github.com/ghodss/yaml"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func TestValidateObject(t *testing.T) {
@@ -65,7 +66,7 @@ func TestValidateObject(t *testing.T) {
 
 	for _, tt := range table {
 		u := unstructured.Unstructured{}
-		o, err := ioutil.ReadFile(tt.path)
+		o, err := os.ReadFile(tt.path)
 		if err != nil {
 			t.Fatalf("reading yaml object file: %s", err)
 		}
@@ -101,5 +102,4 @@ func TestValidateObject(t *testing.T) {
 			}
 		}
 	}
-
 }

--- a/pkg/validation/internal/operatorgroup_test.go
+++ b/pkg/validation/internal/operatorgroup_test.go
@@ -1,11 +1,12 @@
 package internal
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/ghodss/yaml"
+
 	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	"github.com/operator-framework/api/pkg/validation/errors"
 )
@@ -33,7 +34,7 @@ func TestValidateOperatorGroup(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		b, err := ioutil.ReadFile(c.operatorGroupPath)
+		b, err := os.ReadFile(c.operatorGroupPath)
 		if err != nil {
 			t.Fatalf("Error reading OperatorGroup path %s: %v", c.operatorGroupPath, err)
 		}

--- a/pkg/validation/internal/operatorhub_test.go
+++ b/pkg/validation/internal/operatorhub_test.go
@@ -4,10 +4,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/operator-framework/api/pkg/manifests"
-	"github.com/operator-framework/api/pkg/operators/v1alpha1"
-
 	"github.com/stretchr/testify/require"
+
+	"github.com/operator-framework/api/pkg/manifests"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 )
 
 func TestValidateBundleOperatorHub(t *testing.T) {
@@ -131,11 +131,11 @@ func TestExtractCategories(t *testing.T) {
 }
 
 func TestCheckSpecIcon(t *testing.T) {
-	validIcon := v1alpha1.Icon{
+	validIcon := operatorsv1alpha1.Icon{
 		Data:      "iVBORw0KGgoAAAANSUhEUgAAAOEAAADZCAYAAADWmle6AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAGXRFWHRTb2Z0d2Fy",
 		MediaType: "image/png",
 	}
-	invalidIcon := v1alpha1.Icon{
+	invalidIcon := operatorsv1alpha1.Icon{
 		MediaType: "image/png",
 	}
 
@@ -143,7 +143,7 @@ func TestCheckSpecIcon(t *testing.T) {
 	invalidMediaTypeIcon.MediaType = "invalid"
 
 	type args struct {
-		icon []v1alpha1.Icon
+		icon []operatorsv1alpha1.Icon
 	}
 	tests := []struct {
 		name        string
@@ -155,7 +155,7 @@ func TestCheckSpecIcon(t *testing.T) {
 	}{
 		{
 			name: "should work with a valid value",
-			args: args{icon: []v1alpha1.Icon{validIcon}},
+			args: args{icon: []operatorsv1alpha1.Icon{validIcon}},
 		},
 		{
 			name:        "should return an warning when the icon is not provided",
@@ -164,20 +164,20 @@ func TestCheckSpecIcon(t *testing.T) {
 		},
 		{
 			name:       "should fail when the data informed for the icon is invalid",
-			args:       args{icon: []v1alpha1.Icon{invalidIcon}},
+			args:       args{icon: []operatorsv1alpha1.Icon{invalidIcon}},
 			wantError:  true,
 			errStrings: []string{"csv.Spec.Icon elements should contain both data and mediatype"},
 		},
 		{
 			name:       "should fail when the data informed has not a valid MediaType",
-			args:       args{icon: []v1alpha1.Icon{invalidMediaTypeIcon}},
+			args:       args{icon: []operatorsv1alpha1.Icon{invalidMediaTypeIcon}},
 			wantError:  true,
 			errStrings: []string{"csv.Spec.Icon invalid does not have a valid mediatype"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			csv := v1alpha1.ClusterServiceVersion{}
+			csv := operatorsv1alpha1.ClusterServiceVersion{}
 			csv.Spec.Icon = tt.args.icon
 			checks := CSVChecks{csv: csv, errs: []error{}, warns: []error{}}
 
@@ -235,7 +235,7 @@ func TestCheckSpecMinKubeVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			csv := v1alpha1.ClusterServiceVersion{}
+			csv := operatorsv1alpha1.ClusterServiceVersion{}
 			csv.Spec.MinKubeVersion = tt.args.minKubeVersion
 			checks := CSVChecks{csv: csv, errs: []error{}, warns: []error{}}
 

--- a/pkg/validation/internal/removed_apis.go
+++ b/pkg/validation/internal/removed_apis.go
@@ -5,10 +5,11 @@ import (
 	"sort"
 
 	"github.com/blang/semver/v4"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	"github.com/operator-framework/api/pkg/manifests"
 	"github.com/operator-framework/api/pkg/validation/errors"
 	interfaces "github.com/operator-framework/api/pkg/validation/interfaces"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // k8sVersionKey defines the key which can be used by its consumers
@@ -49,7 +50,6 @@ var K8sVersionsSupportedByValidator = []string{"1.22.0", "1.25.0", "1.26.0"}
 var AlphaDeprecatedAPIsValidator interfaces.Validator = interfaces.ValidatorFunc(validateDeprecatedAPIsValidator)
 
 func validateDeprecatedAPIsValidator(objs ...interface{}) (results []errors.ManifestResult) {
-
 	// Obtain the k8s version if informed via the objects an optional
 	k8sVersion := ""
 	for _, obj := range objs {
@@ -144,9 +144,12 @@ func validateDeprecatedAPIS(bundle *manifests.Bundle, versionProvided string) (e
 // for the version informed (k8sVersionToCheck)
 func checkRemovedAPIsForVersion(
 	bundle *manifests.Bundle,
-	k8sVersionToCheck, semVerVersionProvided, semverMinKube semver.Version,
-	errs []error, warns []error) ([]error, []error) {
-
+	k8sVersionToCheck,
+	semVerVersionProvided,
+	semverMinKube semver.Version,
+	errs []error,
+	warns []error,
+) ([]error, []error) {
 	found := map[string][]string{}
 	switch k8sVersionToCheck.String() {
 	case "1.22.0":
@@ -220,11 +223,11 @@ func generateMessageWithDeprecatedAPIs(deprecatedAPIs map[string][]string) strin
 func getRemovedAPIsOn1_22From(bundle *manifests.Bundle) map[string][]string {
 	deprecatedAPIs := make(map[string][]string)
 	if len(bundle.V1beta1CRDs) > 0 {
-		var crdApiNames []string
+		var crdAPINames []string
 		for _, obj := range bundle.V1beta1CRDs {
-			crdApiNames = append(crdApiNames, obj.Name)
+			crdAPINames = append(crdAPINames, obj.Name)
 		}
-		deprecatedAPIs["CRD"] = crdApiNames
+		deprecatedAPIs["CRD"] = crdAPINames
 	}
 
 	for _, obj := range bundle.Objects {

--- a/pkg/validation/internal/removed_apis_test.go
+++ b/pkg/validation/internal/removed_apis_test.go
@@ -6,8 +6,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/operator-framework/api/pkg/manifests"
 	"github.com/stretchr/testify/require"
+
+	"github.com/operator-framework/api/pkg/manifests"
 )
 
 func Test_GetRemovedAPIsOn1_22From(t *testing.T) {
@@ -54,7 +55,6 @@ func Test_GetRemovedAPIsOn1_22From(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			// Validate the bundle object
 			bundle, err := manifests.GetBundleFromDir(tt.args.bundleDir)
 			require.NoError(t, err)
@@ -96,7 +96,6 @@ func Test_GetRemovedAPIsOn1_25From(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			// Validate the bundle object
 			bundle, err := manifests.GetBundleFromDir(tt.args.bundleDir)
 			require.NoError(t, err)
@@ -137,7 +136,6 @@ func Test_GetRemovedAPIsOn1_26From(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			// Validate the bundle object
 			bundle, err := manifests.GetBundleFromDir(tt.args.bundleDir)
 			require.NoError(t, err)

--- a/pkg/validation/internal/test_suite.go
+++ b/pkg/validation/internal/test_suite.go
@@ -3,9 +3,9 @@ package internal
 import (
 	"testing"
 
-	"github.com/operator-framework/api/pkg/validation/errors"
-
 	"github.com/stretchr/testify/require"
+
+	"github.com/operator-framework/api/pkg/validation/errors"
 )
 
 type validatorFuncTest struct {

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -31,8 +31,8 @@ var BundleValidator = internal.BundleValidator
 // for OperatorHub.io requirements.
 var OperatorHubValidator = internal.OperatorHubValidator
 
-// Object Validator validates various custom objects in the bundle like PDBs and SCCs.
-// Object validation is optional and not a default-level validation.
+// ObjectValidator validates various custom objects in the bundle like PDBs and SCCs.
+// ObjectValidator is optional and not a default-level validation.
 var ObjectValidator = internal.ObjectValidator
 
 // OperatorGroupValidator implements Validator to validate OperatorGroup manifests


### PR DESCRIPTION
Add the golangci-lint linter tool to the repository in order to consolidate the various linting checks. Add a GHA job that runs the lint makefile target. Fixes any linting violations that exposed when running the `make lint` check.