### PR TITLE
Fix a panic when reading annotations if the bundle is not there

### DIFF
--- a/pkg/manifests/bundleloader.go
+++ b/pkg/manifests/bundleloader.go
@@ -51,6 +51,10 @@ func (b *bundleLoader) LoadBundle() error {
 
 // Add values from the annotations when the values are not loaded
 func (b *bundleLoader) addChannelsFromAnnotationsFile() {
+	if b.bundle == nil {
+		// None of this is relevant if the bundle was not found
+		return
+	}
 	// Note that they will not get load for Bundle Format directories
 	// and PackageManifest should not have the annotationsFile. However,
 	// the following check to ensure that channels and default channels


### PR DESCRIPTION
If the bundle is not present, the current bundleLoader will panic
when it gets to addChannelsFromAnnotationsFile. If the bundle is
nil, addChannelsFromAnnotationsFile should not attempt to do anything
so instead it just returns now.

Signed-off-by: Brad P. Crochet <brad@redhat.com>