### PR TITLE
update k8s 1.25 validation logic

### DIFF
--- a/pkg/validation/internal/removed_apis.go
+++ b/pkg/validation/internal/removed_apis.go
@@ -374,7 +374,6 @@ func getRemovedAPIsOn1_25From(bundle *manifests.Bundle) (map[string][]string, ma
 						for i, desc := range crdDescriptions {
 							for j, res := range desc.Resources {
 								resFromKind := fmt.Sprintf("%ss", strings.ToLower(res.Kind))
-								fmt.Println("XXX resFromKind:", resFromKind)
 								resInCsvCrds[resFromKind] = struct{}{}
 								unstruct := &unstructured.Unstructured{
 									Object: map[string]interface{}{
@@ -396,8 +395,6 @@ func getRemovedAPIsOn1_25From(bundle *manifests.Bundle) (map[string][]string, ma
 					// Check the Required Resources
 					crdCheck("Required", csv.Spec.CustomResourceDefinitions.Required)
 
-					fmt.Println("XXX resInCsvCrds:", resInCsvCrds)
-
 					// Loop through all the StrategyDeploymentPermissions to see
 					// if the rbacv1.PolicyRule that is defined specifies a resource that
 					// *may* have a deprecated API then add it to the warnings.
@@ -408,7 +405,6 @@ func getRemovedAPIsOn1_25From(bundle *manifests.Bundle) (map[string][]string, ma
 							for j, rule := range perm.Rules {
 								for _, res := range rule.Resources {
 									if _, ok := resInCsvCrds[res]; ok {
-										fmt.Println("XXX resource: ", res, "is in resInCsvCrds map!")
 										continue
 									}
 									warnIfDeprecated(res, fmt.Sprintf("ClusterServiceVersion.Spec.InstallStrategy.StrategySpec.%s[%d].Rules[%d]", permField, i, j))

--- a/pkg/validation/internal/testdata/removed_api_1_25/memcached-operator.clusterserviceversion.yaml
+++ b/pkg/validation/internal/testdata/removed_api_1_25/memcached-operator.clusterserviceversion.yaml
@@ -27,11 +27,6 @@ spec:
       kind: Memcached
       name: memcacheds.cache.example.com
       version: v1alpha1
-    - description: CronJob
-      displayName: CronJob
-      kind: CronJob
-      name: batch
-      version: v1beta1
   description: Memcached Operator description. TODO.
   displayName: Memcached Operator
   icon:

--- a/pkg/validation/internal/testdata/removed_api_1_25/memcached-operator.clusterserviceversion.yaml
+++ b/pkg/validation/internal/testdata/removed_api_1_25/memcached-operator.clusterserviceversion.yaml
@@ -27,6 +27,11 @@ spec:
       kind: Memcached
       name: memcacheds.cache.example.com
       version: v1alpha1
+    - description: CronJob
+      displayName: CronJob
+      kind: CronJob
+      name: batch
+      version: v1beta1
   description: Memcached Operator description. TODO.
   displayName: Memcached Operator
   icon:
@@ -94,6 +99,12 @@ spec:
           - subjectaccessreviews
           verbs:
           - create
+        - apiGroups:
+          - batch
+          resources:
+          - cronjobs
+          verbs:
+          - get
         serviceAccountName: memcached-operator-controller-manager
       deployments:
       - name: memcached-operator-controller-manager

--- a/pkg/validation/internal/testdata/valid_bundle_v1/memcached-operator.clusterserviceversion.yaml
+++ b/pkg/validation/internal/testdata/valid_bundle_v1/memcached-operator.clusterserviceversion.yaml
@@ -176,13 +176,6 @@ spec:
           - update
           - patch
           - delete
-        - apiGroups:
-          - ""
-          resources:
-          - events
-          verbs:
-          - create
-          - patch
         serviceAccountName: memcached-operator-controller-manager
     strategy: deployment
   installModes:


### PR DESCRIPTION
**Description of the change:**
- Updates validation logic for Kubernetes 1.25 deprecated APIs to also look for deprecated APIs in the following CSV fields:
    - `ClusterServiceVersion.Spec.InstallStrategy.StrategySpec.ClusterPermissions[].Rules[]`
        - if the resource specified could potentially have a deprecated API create a warning
            - If the resource has been specified in the `ClusterServiceVersion.Spec.CustomResourceDefinitions` a warning is not raised
    - `ClusterServiceVersion.Spec.InstallStrategy.StrategySpec.Permissions[].Rules[]`
        - if the resource specified could potentially have a deprecated API create a warning
            - If the resource has been specified in the `ClusterServiceVersion.Spec.CustomResourceDefinitions` a warning is not raised
    - `ClusterServiceVersion.Spec.CustomResourceDefinitions.Owned[].Resources[]`
        - if an owned resource is of a deprecated API create an error
    - `ClusterServiceVersion.Spec.CustomResourceDefinitions.Owned[].Resources[]`
        - if an owned resource is of a deprecated API create an error
- Updates the test logic and testdata as necessary to verify these changes work as expected

**Motivation for the change:**
- Check the CSV fields to see if there are any references to APIs deprecated in Kubernetes 1.25
    - For some extra context, there is a JIRA ticket created to track this work: https://issues.redhat.com/browse/OSDK-2567 (i didn't see an upstream issue for it in this repo)