### PR TITLE
Catch whitespace csv.spec.provider.name values

### DIFF
--- a/pkg/validation/internal/operatorhub.go
+++ b/pkg/validation/internal/operatorhub.go
@@ -354,7 +354,7 @@ func checkSpecMaintainers(checks CSVChecks) CSVChecks {
 
 // checkSpecProviderName will validate the values informed via csv.Spec.Provider.Name
 func checkSpecProviderName(checks CSVChecks) CSVChecks {
-	if checks.csv.Spec.Provider.Name == "" {
+	if strings.TrimSpace(checks.csv.Spec.Provider.Name) == "" {
 		checks.errs = append(checks.errs, fmt.Errorf("csv.Spec.Provider.Name not specified"))
 	}
 	return checks


### PR DESCRIPTION
This PR addresses cases where bundle validate fails to catch a provider.name value of `" "` as an empty value. 

This solution trims whitespace for the value before evaluating for emptiness to address this case.

Signed-off-by: Jose R. Gonzalez <jose@flutes.dev>