### PR TITLE
(bugfix): make k8s 1.25 validation logic check api group before issuing a warning

### DIFF
--- a/pkg/validation/internal/removed_apis_test.go
+++ b/pkg/validation/internal/removed_apis_test.go
@@ -73,7 +73,12 @@ func Test_GetRemovedAPIsOn1_25From(t *testing.T) {
 
 	warnMock := make(map[string][]string)
 	warnMock["cronjobs"] = []string{"ClusterServiceVersion.Spec.InstallStrategy.StrategySpec.ClusterPermissions[0].Rules[7]"}
+	warnMock["endpointslices"] = []string{"ClusterServiceVersion.Spec.InstallStrategy.StrategySpec.Permissions[0].Rules[3]"}
 	warnMock["events"] = []string{"ClusterServiceVersion.Spec.InstallStrategy.StrategySpec.Permissions[0].Rules[2]"}
+	warnMock["horizontalpodautoscalers"] = []string{"ClusterServiceVersion.Spec.InstallStrategy.StrategySpec.Permissions[0].Rules[4]"}
+	warnMock["poddisruptionbudgets"] = []string{"ClusterServiceVersion.Spec.InstallStrategy.StrategySpec.Permissions[0].Rules[5]"}
+	warnMock["podsecuritypolicies"] = []string{"ClusterServiceVersion.Spec.InstallStrategy.StrategySpec.Permissions[0].Rules[5]"}
+	warnMock["runtimeclasses"] = []string{"ClusterServiceVersion.Spec.InstallStrategy.StrategySpec.Permissions[0].Rules[6]"}
 
 	type args struct {
 		bundleDir string
@@ -96,6 +101,14 @@ func Test_GetRemovedAPIsOn1_25From(t *testing.T) {
 			name: "should fail return the removed APIs in 1.25",
 			args: args{
 				bundleDir: "./testdata/removed_api_1_25",
+			},
+			errWant:  mock,
+			warnWant: map[string][]string{},
+		},
+		{
+			name: "should return warnings with all deprecated APIs in 1.25",
+			args: args{
+				bundleDir: "./testdata/deprecated_api_1_25",
 			},
 			errWant:  mock,
 			warnWant: warnMock,
@@ -187,11 +200,7 @@ func TestValidateDeprecatedAPIS(t *testing.T) {
 			warnStrings: []string{"this bundle is using APIs which were deprecated and removed in v1.22. " +
 				"More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22. " +
 				"Migrate the API(s) for CRD: ([\"etcdbackups.etcd.database.coreos.com\" " +
-				"\"etcdclusters.etcd.database.coreos.com\" \"etcdrestores.etcd.database.coreos.com\"])",
-				"this bundle is using APIs which were deprecated and removed in v1.25. " +
-					"More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-25. " +
-					"Migrate the API(s) for events: " +
-					"([\"ClusterServiceVersion.Spec.InstallStrategy.StrategySpec.Permissions[0].Rules[1]\"])"},
+				"\"etcdclusters.etcd.database.coreos.com\" \"etcdrestores.etcd.database.coreos.com\"])"},
 		},
 		{
 			name: "should return an error when the k8sVersion is >= 1.22 and has the deprecated API",
@@ -205,11 +214,6 @@ func TestValidateDeprecatedAPIS(t *testing.T) {
 				"More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22. " +
 				"Migrate the API(s) for CRD: ([\"etcdbackups.etcd.database.coreos.com\"" +
 				" \"etcdclusters.etcd.database.coreos.com\" \"etcdrestores.etcd.database.coreos.com\"])"},
-			wantWarning: true,
-			warnStrings: []string{"this bundle is using APIs which were deprecated and removed in v1.25. " +
-				"More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-25. " +
-				"Migrate the API(s) for events: " +
-				"([\"ClusterServiceVersion.Spec.InstallStrategy.StrategySpec.Permissions[0].Rules[1]\"])"},
 		},
 		{
 			name: "should return an error when the k8sVersion is >= 1.25 and found removed APIs on 1.25",
@@ -223,12 +227,6 @@ func TestValidateDeprecatedAPIS(t *testing.T) {
 				"More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-25. " +
 				"Migrate the API(s) for HorizontalPodAutoscaler: ([\"memcached-operator-hpa\"])," +
 				"PodDisruptionBudget: ([\"memcached-operator-policy-manager\"]),"},
-			wantWarning: true,
-			warnStrings: []string{"this bundle is using APIs which were deprecated and removed in v1.25. " +
-				"More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-25. " +
-				"Migrate the API(s) for cronjobs: " +
-				"([\"ClusterServiceVersion.Spec.InstallStrategy.StrategySpec.ClusterPermissions[0].Rules[7]\"])" +
-				",events: ([\"ClusterServiceVersion.Spec.InstallStrategy.StrategySpec.Permissions[0].Rules[2]\"]),"},
 		},
 		{
 			name: "should return a warning if the k8sVersion is empty and found removed APIs on 1.25",
@@ -241,12 +239,7 @@ func TestValidateDeprecatedAPIS(t *testing.T) {
 			warnStrings: []string{"this bundle is using APIs which were deprecated and removed in v1.25. " +
 				"More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-25. " +
 				"Migrate the API(s) for HorizontalPodAutoscaler: ([\"memcached-operator-hpa\"])," +
-				"PodDisruptionBudget: ([\"memcached-operator-policy-manager\"]),",
-				"this bundle is using APIs which were deprecated and removed in v1.25. " +
-					"More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-25. " +
-					"Migrate the API(s) for cronjobs: " +
-					"([\"ClusterServiceVersion.Spec.InstallStrategy.StrategySpec.ClusterPermissions[0].Rules[7]\"])" +
-					",events: ([\"ClusterServiceVersion.Spec.InstallStrategy.StrategySpec.Permissions[0].Rules[2]\"]),"},
+				"PodDisruptionBudget: ([\"memcached-operator-policy-manager\"]),"},
 		},
 		{
 			name: "should return an error when the k8sVersion is >= 1.26 and found removed APIs on 1.26",
@@ -259,11 +252,6 @@ func TestValidateDeprecatedAPIS(t *testing.T) {
 			errStrings: []string{"this bundle is using APIs which were deprecated and removed in v1.26. " +
 				"More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-26. " +
 				"Migrate the API(s) for HorizontalPodAutoscaler: ([\"memcached-operator-hpa\"])"},
-			wantWarning: true,
-			warnStrings: []string{"this bundle is using APIs which were deprecated and removed in v1.25. " +
-				"More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-25. " +
-				"Migrate the API(s) for events: " +
-				"([\"ClusterServiceVersion.Spec.InstallStrategy.StrategySpec.Permissions[0].Rules[2]\"])"},
 		},
 		{
 			name: "should return a warning when the k8sVersion is empty and found removed APIs on 1.26",
@@ -273,13 +261,9 @@ func TestValidateDeprecatedAPIS(t *testing.T) {
 				directory:      "./testdata/removed_api_1_26",
 			},
 			wantWarning: true,
-			warnStrings: []string{"this bundle is using APIs which were deprecated and removed in v1.25. " +
-				"More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-25. " +
-				"Migrate the API(s) for events: " +
-				"([\"ClusterServiceVersion.Spec.InstallStrategy.StrategySpec.Permissions[0].Rules[2]\"])",
-				"this bundle is using APIs which were deprecated and removed in v1.26. " +
-					"More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-26. " +
-					"Migrate the API(s) for HorizontalPodAutoscaler: ([\"memcached-operator-hpa\"])"},
+			warnStrings: []string{"this bundle is using APIs which were deprecated and removed in v1.26. " +
+				"More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-26. " +
+				"Migrate the API(s) for HorizontalPodAutoscaler: ([\"memcached-operator-hpa\"])"},
 		},
 		{
 			name: "should return an error when the k8sVersion informed is invalid",
@@ -294,11 +278,7 @@ func TestValidateDeprecatedAPIS(t *testing.T) {
 			warnStrings: []string{"this bundle is using APIs which were deprecated and removed in v1.22. " +
 				"More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22. " +
 				"Migrate the API(s) for CRD: ([\"etcdbackups.etcd.database.coreos.com\" " +
-				"\"etcdclusters.etcd.database.coreos.com\" \"etcdrestores.etcd.database.coreos.com\"])",
-				"this bundle is using APIs which were deprecated and removed in v1.25. " +
-					"More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-25. " +
-					"Migrate the API(s) for events: " +
-					"([\"ClusterServiceVersion.Spec.InstallStrategy.StrategySpec.Permissions[0].Rules[1]\"])"},
+				"\"etcdclusters.etcd.database.coreos.com\" \"etcdrestores.etcd.database.coreos.com\"])"},
 		},
 		{
 			name: "should return an error when the csv.spec.minKubeVersion informed is invalid",
@@ -313,11 +293,7 @@ func TestValidateDeprecatedAPIS(t *testing.T) {
 			warnStrings: []string{"this bundle is using APIs which were deprecated and removed in v1.22. " +
 				"More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22. " +
 				"Migrate the API(s) for CRD: ([\"etcdbackups.etcd.database.coreos.com\" " +
-				"\"etcdclusters.etcd.database.coreos.com\" \"etcdrestores.etcd.database.coreos.com\"])",
-				"this bundle is using APIs which were deprecated and removed in v1.25. " +
-					"More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-25. " +
-					"Migrate the API(s) for events: " +
-					"([\"ClusterServiceVersion.Spec.InstallStrategy.StrategySpec.Permissions[0].Rules[1]\"])"},
+				"\"etcdclusters.etcd.database.coreos.com\" \"etcdrestores.etcd.database.coreos.com\"])"},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/validation/internal/testdata/deprecated_api_1_25/cache.example.com_memcacheds.yaml
+++ b/pkg/validation/internal/testdata/deprecated_api_1_25/cache.example.com_memcacheds.yaml
@@ -1,0 +1,66 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: memcacheds.cache.example.com
+spec:
+  group: cache.example.com
+  names:
+    kind: Memcached
+    listKind: MemcachedList
+    plural: memcacheds
+    singular: memcached
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Memcached is the Schema for the memcacheds API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MemcachedSpec defines the desired state of Memcached
+            properties:
+              foo:
+                description: Foo is an example field of Memcached. Edit memcached_types.go
+                  to remove/update
+                type: string
+              size:
+                description: Size defines the number of Memcached instances
+                format: int32
+                type: integer
+            type: object
+          status:
+            description: MemcachedStatus defines the observed state of Memcached
+            properties:
+              nodes:
+                description: Nodes store the name of the pods which are running Memcached
+                  instances
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/validation/internal/testdata/deprecated_api_1_25/horizontal-pod.yaml
+++ b/pkg/validation/internal/testdata/deprecated_api_1_25/horizontal-pod.yaml
@@ -1,0 +1,18 @@
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: memcached-operator-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: memcached-operator-controller-manager
+  minReplicas: 1
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 50

--- a/pkg/validation/internal/testdata/deprecated_api_1_25/memcached-operator.clusterserviceversion.yaml
+++ b/pkg/validation/internal/testdata/deprecated_api_1_25/memcached-operator.clusterserviceversion.yaml
@@ -94,6 +94,12 @@ spec:
           - subjectaccessreviews
           verbs:
           - create
+        - apiGroups:
+          - batch
+          resources:
+          - cronjobs
+          verbs:
+          - get
         serviceAccountName: memcached-operator-controller-manager
       deployments:
       - name: memcached-operator-controller-manager
@@ -177,9 +183,38 @@ spec:
           - patch
           - delete
         - apiGroups:
-          - ""
+          - events.k8s.io
           resources:
           - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - discovery.k8s.io
+          resources:
+          - endpointslices
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - autoscaling
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          - podsecuritypolicies
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - node.k8s.io
+          resources:
+          - runtimeclasses
           verbs:
           - create
           - patch

--- a/pkg/validation/internal/testdata/deprecated_api_1_25/policy.yaml
+++ b/pkg/validation/internal/testdata/deprecated_api_1_25/policy.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: memcached-operator-policy-manager
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: memcached-operator


### PR DESCRIPTION
## Description of Change
This PR updates the k8s 1.25 validation logic and the associated test cases to verify if any of the `apiGroups` defined in an RBAC `PolicyRule` has a potential deprecation. If it finds one it will check a combination of the `apiGroup` and all resources defined in the `PolicyRule` (i.e `apiGroup/resource`) to see if any of these combinations results in a deprecated API - if so it returns a warning.

## Motivation for Change
There was a bug in the validation logic where it was issuing a warning even if the API group the resource belonged to had not been deprecated.