### PR TITLE
Restores openapi-gen tag for `APIResourceReference`

### DIFF
--- a/pkg/operators/v1alpha1/clusterserviceversion_types.go
+++ b/pkg/operators/v1alpha1/clusterserviceversion_types.go
@@ -146,6 +146,7 @@ type APIServiceDescription struct {
 }
 
 // APIResourceReference is a reference to a Kubernetes resource type that the referrer utilizes.
+// +k8s:openapi-gen=true
 type APIResourceReference struct {
 	// Plural name of the referenced resource type (CustomResourceDefinition.Spec.Names[].Plural). Empty string if the referenced resource type is not a custom resource.
 	Name string `json:"name"`


### PR DESCRIPTION
It looks like it was accidentally removed in #168.

Now when we [update `github.com/operator-framework/api` package](https://github.com/operator-framework/operator-lifecycle-manager/pull/2954) for OLM, packageserver fails with the following error:

> unable to get openapi models: cannot find model definition for github.com/operator-framework/api/pkg/operators/v1alpha1.APIResourceReference. If you added a new type, you may need to add +k8s:openapi-gen=true to the package or type and run code-gen again
