### PR TITLE
Fix min kube version validation

### DIFF
--- a/pkg/validation/internal/csv.go
+++ b/pkg/validation/internal/csv.go
@@ -44,7 +44,7 @@ func validateCSV(csv *v1alpha1.ClusterServiceVersion) errors.ManifestResult {
 	}
 	// validate example annotations ("alm-examples", "olm.examples").
 	result.Add(validateExamplesAnnotations(csv)...)
-	// validate spec
+	// validate installModes
 	result.Add(validateInstallModes(csv)...)
 	// validate min Kubernetes version
 	result.Add(validateMinKubeVersion(*csv)...)

--- a/pkg/validation/internal/csv.go
+++ b/pkg/validation/internal/csv.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/blang/semver/v4"
 	"io"
 	"reflect"
 	"strings"
@@ -43,8 +44,10 @@ func validateCSV(csv *v1alpha1.ClusterServiceVersion) errors.ManifestResult {
 	}
 	// validate example annotations ("alm-examples", "olm.examples").
 	result.Add(validateExamplesAnnotations(csv)...)
-	// validate installModes
+	// validate spec
 	result.Add(validateInstallModes(csv)...)
+	// validate min Kubernetes version
+	result.Add(validateMinKubeVersion(*csv)...)
 	// check missing optional/mandatory fields.
 	result.Add(checkFields(*csv)...)
 	// validate case sensitive annotation names
@@ -239,4 +242,16 @@ func validateVersionKind(csv *v1alpha1.ClusterServiceVersion) (errs []errors.Err
 		errs = append(errs, errors.ErrInvalidCSV("'kind' is missing", csv.GetName()))
 	}
 	return
+}
+
+// validateMinKubeVersion checks format of spec.minKubeVersion field
+func validateMinKubeVersion(csv v1alpha1.ClusterServiceVersion) (errs []errors.Error) {
+	if len(strings.TrimSpace(csv.Spec.MinKubeVersion)) == 0 {
+		errs = append(errs, errors.WarnInvalidCSV(minKubeVersionWarnMessage, csv.GetName()))
+	} else {
+		if _, err := semver.Parse(csv.Spec.MinKubeVersion); err != nil {
+			errs = append(errs, errors.ErrInvalidCSV(fmt.Sprintf("csv.Spec.MinKubeVersion has an invalid value: %s", csv.Spec.MinKubeVersion), csv.GetName()))
+		}
+	}
+	return errs
 }

--- a/pkg/validation/internal/csv_test.go
+++ b/pkg/validation/internal/csv_test.go
@@ -2,10 +2,11 @@ package internal
 
 import (
 	"fmt"
-	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"io/ioutil"
 	"path/filepath"
 	"testing"
+
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 
 	"github.com/ghodss/yaml"
 	"github.com/operator-framework/api/pkg/validation/errors"

--- a/pkg/validation/internal/csv_test.go
+++ b/pkg/validation/internal/csv_test.go
@@ -2,12 +2,12 @@ package internal
 
 import (
 	"fmt"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"io/ioutil"
 	"path/filepath"
 	"testing"
 
 	"github.com/ghodss/yaml"
-	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/api/pkg/validation/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -106,6 +106,16 @@ func TestValidateCSV(t *testing.T) {
 				},
 			},
 			filepath.Join("testdata", "correct.csv.olm.properties.annotation.yaml"),
+		},
+		{
+			validatorFuncTest{
+				description: "should fail when spec.minKubeVersion is not in semantic version format",
+				wantErr:     true,
+				errors: []errors.Error{
+					errors.ErrInvalidCSV(`csv.Spec.MinKubeVersion has an invalid value: 1.21`, "test-operator.v0.0.1"),
+				},
+			},
+			filepath.Join("testdata", "invalid_min_kube_version.csv.yaml"),
 		},
 	}
 

--- a/pkg/validation/internal/operatorhub.go
+++ b/pkg/validation/internal/operatorhub.go
@@ -240,7 +240,7 @@ func checkSpecMinKubeVersion(checks CSVChecks) CSVChecks {
 	if len(strings.TrimSpace(checks.csv.Spec.MinKubeVersion)) == 0 {
 		checks.warns = append(checks.warns, fmt.Errorf(minKubeVersionWarnMessage))
 	} else {
-		if _, err := semver.ParseTolerant(checks.csv.Spec.MinKubeVersion); err != nil {
+		if _, err := semver.Parse(checks.csv.Spec.MinKubeVersion); err != nil {
 			checks.errs = append(checks.errs, fmt.Errorf("csv.Spec.MinKubeVersion has an invalid value: %s", checks.csv.Spec.MinKubeVersion))
 		}
 	}

--- a/pkg/validation/internal/operatorhub_test.go
+++ b/pkg/validation/internal/operatorhub_test.go
@@ -218,7 +218,7 @@ func TestCheckSpecMinKubeVersion(t *testing.T) {
 	}{
 		{
 			name: "should work with a valid value",
-			args: args{minKubeVersion: "1.16"},
+			args: args{minKubeVersion: "1.16.0"},
 		},
 		{
 			name:        "should return a warning when the minKubeVersion is not informed ",

--- a/pkg/validation/internal/testdata/badAnnotationNames.csv.yaml
+++ b/pkg/validation/internal/testdata/badAnnotationNames.csv.yaml
@@ -14,6 +14,7 @@ metadata:
     alm-examples: '[{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdCluster","metadata":{"name":"example","namespace":"default"},"spec":{"size":3,"version":"3.2.13"}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdRestore","metadata":{"name":"example-etcd-cluster"},"spec":{"etcdCluster":{"name":"example-etcd-cluster"},"backupStorageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdBackup","metadata":{"name":"example-etcd-cluster-backup"},"spec":{"etcdEndpoints":["<etcd-cluster-endpoints>"],"storageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}}]'
     description: etcd is a distributed key value store providing a reliable way to store data across a cluster of machines.
 spec:
+  minKubeVersion: 1.21.0
   displayName: etcd
   description: |
     etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines. It’s open-source and available on GitHub. etcd gracefully handles leader elections during network partitions and will tolerate machine failure, including the leader. Your applications can read and write data into etcd.

--- a/pkg/validation/internal/testdata/badName.csv.yaml
+++ b/pkg/validation/internal/testdata/badName.csv.yaml
@@ -11,6 +11,7 @@ metadata:
     alm-examples: '[{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdCluster","metadata":{"name":"example","namespace":"default"},"spec":{"size":3,"version":"3.2.13"}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdRestore","metadata":{"name":"example-etcd-cluster"},"spec":{"etcdCluster":{"name":"example-etcd-cluster"},"backupStorageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdBackup","metadata":{"name":"example-etcd-cluster-backup"},"spec":{"etcdEndpoints":["<etcd-cluster-endpoints>"],"storageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}}]'
     description: etcd is a distributed key value store providing a reliable way to store data across a cluster of machines.
 spec:
+  minKubeVersion: 1.21.0
   displayName: etcd
   description: something
   keywords: ['etcd', 'key value', 'database', 'coreos', 'open source']

--- a/pkg/validation/internal/testdata/correct.csv.empty.example.yaml
+++ b/pkg/validation/internal/testdata/correct.csv.empty.example.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     "alm-examples": ""
 spec:
+  minKubeVersion: 1.21.0
   version: 0.9.0
   installModes:
   - type: AllNamespaces

--- a/pkg/validation/internal/testdata/correct.csv.olm.properties.annotation.yaml
+++ b/pkg/validation/internal/testdata/correct.csv.olm.properties.annotation.yaml
@@ -9,6 +9,7 @@ metadata:
     alm-examples: '[{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdCluster","metadata":{"name":"example","namespace":"default"},"spec":{"size":3,"version":"3.2.13"}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdRestore","metadata":{"name":"example-etcd-cluster"},"spec":{"etcdCluster":{"name":"example-etcd-cluster"},"backupStorageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdBackup","metadata":{"name":"example-etcd-cluster-backup"},"spec":{"etcdEndpoints":["<etcd-cluster-endpoints>"],"storageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}}]'
     olm.properties: '[{"type": "foo", "value": "bar"}]'
 spec:
+  minKubeVersion: 1.21.0
   version: 0.9.0
   installModes:
   - type: AllNamespaces

--- a/pkg/validation/internal/testdata/correct.csv.with.conversion.webhook.yaml
+++ b/pkg/validation/internal/testdata/correct.csv.with.conversion.webhook.yaml
@@ -11,6 +11,7 @@ metadata:
     alm-examples: '[{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdCluster","metadata":{"name":"example","namespace":"default"},"spec":{"size":3,"version":"3.2.13"}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdRestore","metadata":{"name":"example-etcd-cluster"},"spec":{"etcdCluster":{"name":"example-etcd-cluster"},"backupStorageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdBackup","metadata":{"name":"example-etcd-cluster-backup"},"spec":{"etcdEndpoints":["<etcd-cluster-endpoints>"],"storageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}}]'
     description: etcd is a distributed key value store providing a reliable way to store data across a cluster of machines.
 spec:
+  minKubeVersion: 1.21.0
   displayName: etcd
   description: |
     etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines. It’s open-source and available on GitHub. etcd gracefully handles leader elections during network partitions and will tolerate machine failure, including the leader. Your applications can read and write data into etcd.

--- a/pkg/validation/internal/testdata/correct.csv.yaml
+++ b/pkg/validation/internal/testdata/correct.csv.yaml
@@ -11,6 +11,7 @@ metadata:
     alm-examples: '[{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdCluster","metadata":{"name":"example","namespace":"default"},"spec":{"size":3,"version":"3.2.13"}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdRestore","metadata":{"name":"example-etcd-cluster"},"spec":{"etcdCluster":{"name":"example-etcd-cluster"},"backupStorageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdBackup","metadata":{"name":"example-etcd-cluster-backup"},"spec":{"etcdEndpoints":["<etcd-cluster-endpoints>"],"storageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}}]'
     description: etcd is a distributed key value store providing a reliable way to store data across a cluster of machines.
 spec:
+  minKubeVersion: 1.21.0
   displayName: etcd
   description: |
     etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines. It’s open-source and available on GitHub. etcd gracefully handles leader elections during network partitions and will tolerate machine failure, including the leader. Your applications can read and write data into etcd.

--- a/pkg/validation/internal/testdata/dataTypeMismatch.csv.yaml
+++ b/pkg/validation/internal/testdata/dataTypeMismatch.csv.yaml
@@ -11,6 +11,7 @@ metadata:
     alm-examples: '[{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdCluster","metadata":{"name":"example","namespace":"default"},"spec":{"size":3,"version":"3.2.13"}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdRestore","metadata":{"name":"example-etcd-cluster"},"spec":{"etcdCluster":{"name":"example-etcd-cluster"},"backupStorageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdBackup","metadata":{"name":"example-etcd-cluster-backup"},"spec":{"etcdEndpoints":["<etcd-cluster-endpoints>"],"storageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}}]'
     description: etcd is a distributed key value store providing a reliable way to store data across a cluster of machines.
 spec:
+  minKubeVersion: 1.21.0
   displayName: etcd
   description: |
     etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines. It’s open-source and available on GitHub. etcd gracefully handles leader elections during network partitions and will tolerate machine failure, including the leader. Your applications can read and write data into etcd.

--- a/pkg/validation/internal/testdata/invalid.alm-examples.csv.yaml
+++ b/pkg/validation/internal/testdata/invalid.alm-examples.csv.yaml
@@ -7,6 +7,7 @@ metadata:
   name: test-operator.v0.0.1
   namespace: placeholder
 spec:
+  minKubeVersion: 1.21.0
   displayName: test-operator
   install:
     strategy: deployment

--- a/pkg/validation/internal/testdata/invalid_min_kube_version.csv.yaml
+++ b/pkg/validation/internal/testdata/invalid_min_kube_version.csv.yaml
@@ -1,0 +1,32 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: test-operator.v0.0.1
+  namespace: placeholder
+spec:
+  minKubeVersion: 1.21
+  displayName: test-operator
+  install:
+    strategy: deployment
+  installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+  keywords:
+    - test-operator
+  links:
+    - name: Test Operator
+      url: https://test-operator.domain
+  maintainers:
+    - email: your@email.com
+      name: Maintainer Name
+  maturity: alpha
+  provider:
+    name: Provider Name
+    url: https://your.domain
+  version: 0.0.1

--- a/pkg/validation/internal/testdata/noInstallMode.csv.yaml
+++ b/pkg/validation/internal/testdata/noInstallMode.csv.yaml
@@ -11,6 +11,7 @@ metadata:
     alm-examples: '[{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdCluster","metadata":{"name":"example","namespace":"default"},"spec":{"size":3,"version":"3.2.13"}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdRestore","metadata":{"name":"example-etcd-cluster"},"spec":{"etcdCluster":{"name":"example-etcd-cluster"},"backupStorageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdBackup","metadata":{"name":"example-etcd-cluster-backup"},"spec":{"etcdEndpoints":["<etcd-cluster-endpoints>"],"storageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}}]'
     description: etcd is a distributed key value store providing a reliable way to store data across a cluster of machines.
 spec:
+  minKubeVersion: 1.21.0
   displayName: etcd
   description: |
     etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines. It’s open-source and available on GitHub. etcd gracefully handles leader elections during network partitions and will tolerate machine failure, including the leader. Your applications can read and write data into etcd.


### PR DESCRIPTION
Fixes https://github.com/operator-framework/operator-sdk/issues/5995
`operator-sdk bundle validate` passes all tests when CSV's `spec.minKubeVersion` with version format `x.y`. However `spec.minKubeVersion` with format `x.y` should be invalid because OLM refuses to deploy the CSV. Basically, this PR adds a validation method `validateMinKubeVersion` that validates if version format is in semantic versioning `x.y.z`. So that `operator-sdk bundle validate` fails before OLM refuses to deploy.