### PR TITLE
Makes codecov-action optional

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -33,7 +33,6 @@ jobs:
     - uses: codecov/codecov-action@v3
       with:
         files: cover.out
-        fail_ci_if_error: true
         functionalities: fixes
 
   go-apidiff:


### PR DESCRIPTION
We do not want to fail the job if codecov fails
to upload the report due to rate limiting.