### PR TITLE
OCPBUGS-17157: operators/v1alpha1: expose CSV copied logic

### DIFF
--- a/pkg/operators/v1alpha1/clusterserviceversion.go
+++ b/pkg/operators/v1alpha1/clusterserviceversion.go
@@ -120,12 +120,19 @@ func (c *ClusterServiceVersion) IsObsolete() bool {
 
 // IsCopied returns true if the CSV has been copied and false otherwise.
 func (c *ClusterServiceVersion) IsCopied() bool {
-	operatorNamespace, ok := c.GetAnnotations()[OperatorGroupNamespaceAnnotationKey]
-	if c.Status.Reason == CSVReasonCopied || ok && c.GetNamespace() != operatorNamespace {
-		return true
+	return c.Status.Reason == CSVReasonCopied || IsCopied(c)
+}
+
+func IsCopied(o metav1.Object) bool {
+	annotations := o.GetAnnotations()
+	if annotations != nil {
+		operatorNamespace, ok := annotations[OperatorGroupNamespaceAnnotationKey]
+		if ok && o.GetNamespace() != operatorNamespace {
+			return true
+		}
 	}
 
-	if labels := c.GetLabels(); labels != nil {
+	if labels := o.GetLabels(); labels != nil {
 		if _, ok := labels[CopiedLabelKey]; ok {
 			return true
 		}


### PR DESCRIPTION
We want to use a partial object metadata query for CSVs to reduce resource utilization. We still want to ask questions about whether these CSVs are copied, so we need to refactor this method to take only object metadata. While it's not a perfect port of the previous logic, it defies explanation how an object would have all the other markings of being copied but the wrong status.