### PR TITLE
Add tidy to the verify target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ TEST_PKGS:=$(shell go list ./...)
 test-unit: ## Run the unit tests
 	$(Q)go test -count=1 -short ${TEST_PKGS}
 
-verify: manifests generate format
+verify: manifests generate format tidy
 	git diff --exit-code
 
 ################


### PR DESCRIPTION
As part of verifying, we should really be checking the status of `go mod tidy`. This can be done by adding the `tidy` target as a dependency of the `verify` target. This will be ussed during github workflows/CI to make sure everything is "tidied".