### PR TITLE
bugfix for catalog-operator and packageserver pods being in CrashLoopBackOff if updateStrategy is empty

### DIFF
--- a/pkg/operators/v1alpha1/catalogsource_types.go
+++ b/pkg/operators/v1alpha1/catalogsource_types.go
@@ -317,24 +317,26 @@ func (c *CatalogSource) Update() bool {
 		return false
 	}
 
-	if c.Spec.UpdateStrategy != nil && c.Spec.UpdateStrategy.RegistryPoll != nil && c.Spec.UpdateStrategy.Interval != nil {
-		interval := c.Spec.UpdateStrategy.Interval.Duration
-		latest := c.Status.LatestImageRegistryPoll
-		if latest == nil {
-			logrus.WithField("CatalogSource", c.Name).Debugf("latest poll %v", latest)
-		} else {
-			logrus.WithField("CatalogSource", c.Name).Debugf("latest poll %v", *c.Status.LatestImageRegistryPoll)
-		}
-
-		if c.Status.LatestImageRegistryPoll.IsZero() {
-			logrus.WithField("CatalogSource", c.Name).Debugf("creation timestamp plus interval before now %t", c.CreationTimestamp.Add(interval).Before(time.Now()))
-			if c.CreationTimestamp.Add(interval).Before(time.Now()) {
-				return true
+	if c.Spec.UpdateStrategy != nil && c.Spec.UpdateStrategy.RegistryPoll != nil {
+		if c.Spec.UpdateStrategy.Interval != nil {
+			interval := c.Spec.UpdateStrategy.Interval.Duration
+			latest := c.Status.LatestImageRegistryPoll
+			if latest == nil {
+				logrus.WithField("CatalogSource", c.Name).Debugf("latest poll %v", latest)
+			} else {
+				logrus.WithField("CatalogSource", c.Name).Debugf("latest poll %v", *c.Status.LatestImageRegistryPoll)
 			}
-		} else {
-			logrus.WithField("CatalogSource", c.Name).Debugf("latest poll plus interval before now %t", c.Status.LatestImageRegistryPoll.Add(interval).Before(time.Now()))
-			if c.Status.LatestImageRegistryPoll.Add(interval).Before(time.Now()) {
-				return true
+
+			if c.Status.LatestImageRegistryPoll.IsZero() {
+				logrus.WithField("CatalogSource", c.Name).Debugf("creation timestamp plus interval before now %t", c.CreationTimestamp.Add(interval).Before(time.Now()))
+				if c.CreationTimestamp.Add(interval).Before(time.Now()) {
+					return true
+				}
+			} else {
+				logrus.WithField("CatalogSource", c.Name).Debugf("latest poll plus interval before now %t", c.Status.LatestImageRegistryPoll.Add(interval).Before(time.Now()))
+				if c.Status.LatestImageRegistryPoll.Add(interval).Before(time.Now()) {
+					return true
+				}
 			}
 		}
 	}

--- a/pkg/operators/v1alpha1/types_test.go
+++ b/pkg/operators/v1alpha1/types_test.go
@@ -272,9 +272,16 @@ func TestUpdateStrategyUnmarshal(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			s := TestStruct{}
 			err := json.Unmarshal(tt.in, &s)
-			require.Equal(t, tt.out.UpdateStrategy.RawInterval, s.UpdateStrategy.RawInterval)
-			require.Equal(t, tt.out.UpdateStrategy.Interval, s.UpdateStrategy.Interval)
-			require.Equal(t, tt.out.UpdateStrategy.ParsingError, s.UpdateStrategy.ParsingError)
+			if s.UpdateStrategy.RegistryPoll != nil {
+				require.Equal(t, tt.out.UpdateStrategy.RawInterval, s.UpdateStrategy.RawInterval)
+			}
+			if s.UpdateStrategy.RegistryPoll != nil && s.UpdateStrategy.Interval != nil {
+				require.Equal(t, tt.out.UpdateStrategy.Interval, s.UpdateStrategy.Interval)
+			}
+
+			if s.UpdateStrategy.RegistryPoll != nil {
+				require.Equal(t, tt.out.UpdateStrategy.ParsingError, s.UpdateStrategy.ParsingError)
+			}
 			require.Equal(t, tt.err, err)
 		})
 	}


### PR DESCRIPTION
Description: 

- dont poll if updateStrategy and any of its child references are empty
- cover the panic by adding nil protection checks along the pointer stack of updateStrategy struct