### PR TITLE
Fix codecov-action params

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -33,8 +33,8 @@ jobs:
       run: go test -v ./... -coverprofile cover.out
     - uses: codecov/codecov-action@v4
       with:
+        disable_search: true
         files: cover.out
-        functionalities: fixes
         token: ${{ secrets.CODECOV_TOKEN }}
 
   go-apidiff:


### PR DESCRIPTION
* `functionalities` param is no longer exist. It was used to enable file fixes to ignore common lines from coverage. This feature is now seems to be on by default.

* Adding `disable_search` because we do not need for the codecov action to search for coverage files: we explicitly provide files.