### PR TITLE
fix: add missing comment tags for Conditions

### DIFF
--- a/pkg/operators/v1alpha1/installplan_types.go
+++ b/pkg/operators/v1alpha1/installplan_types.go
@@ -277,6 +277,8 @@ type BundleLookup struct {
 	CatalogSourceRef *corev1.ObjectReference `json:"catalogSourceRef"`
 	// Conditions represents the overall state of a BundleLookup.
 	// +optional
+	// +patchMergeKey=type
+	// +patchStrategy=merge
 	Conditions []BundleLookupCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 	// The effective properties of the unpacked bundle.
 	// +optional


### PR DESCRIPTION
## Descriptions

The tags for the Conditions field in BundleLookup are missing.
This causes issues while trying to generate OpenAPI specs for these structs.