### PR TITLE
:seedling: Group k8s and golang.org/x dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      k8s-dependencies:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      golang-x-deps:
+        patterns:
+          - "golang.org/x/*"


### PR DESCRIPTION
Reduce number of dependabot PRs by grouping k8s and golang.org dependencies