### PR TITLE
🌱 (cleanup): Update Owner Alias - remove inactive maintainers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,29 +1,17 @@
 # approval == this is a good idea /approve
 approvers:
-  - ecordell
-  - njhale
-  - dinhxuanvu
   - kevinrizza
-  - benluddy
-  - awgreene
   - joelanford
-  - jmrodri
   - perdasilva
   - grokspawn
+
 # review == this code is good /lgtm
 reviewers:
-  - ecordell
-  - njhale
-  - dinhxuanvu
   - kevinrizza
-  - gallettilance
   - anik120
   - exdx
-  - awgreene
   - joelanford
-  - benluddy
   - ankitathomas
-  - jmrodri
   - perdasilva
   - grokspawn
   - oceanc80


### PR DESCRIPTION
Removed maintainers from the Owner Alias who are no longer active in the project, in accordance with the [Contributor Ladder guidelines on inactive members](https://github.com/operator-framework/community/blob/master/contributor-ladder.md#inactive-members). They are invited to self-select emeritus status as outlined in the community process.