### PR TITLE
Allow override of go-verdiff result via label

### DIFF
--- a/.github/workflows/go-verdiff.yaml
+++ b/.github/workflows/go-verdiff.yaml
@@ -1,17 +1,22 @@
 name: go-verdiff
 on:
   pull_request:
-    paths:
-      - '**.mod'
-      - '.github/workflows/go-verdiff.yaml'
     branches:
       - master
 jobs:
   go-verdiff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Check golang version
-        run: hack/tools/check-go-version.sh "${{ github.event.pull_request.base.sha }}"
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Check golang version
+      run: |
+        export LABELS="$(gh api repos/$OWNER/$REPO/pulls/$PR --jq '.labels.[].name')"
+        hack/tools/check-go-version.sh -b "${{ github.event.pull_request.base.sha }}"
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        OWNER: ${{ github.repository_owner }}
+        REPO: ${{ github.event.repository.name }}
+        PR: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Rather than disabling the go-verdiff CI to allow it to pass when there is a legitimate golang version change, use a label to override the test results.

The label is `(override-go-verdiff)`.

See: https://github.com/operator-framework/operator-controller/pull/1964/