### PR TITLE
fix(pkg/validation/internal): check nil pointers before dereference

### DIFF
--- a/pkg/validation/internal/community.go
+++ b/pkg/validation/internal/community.go
@@ -69,11 +69,12 @@ type CommunityOperatorChecks struct {
 
 // validateCommunityBundle will check the bundle against the community-operator criterias
 func validateCommunityBundle(bundle *manifests.Bundle, indexImagePath string) errors.ManifestResult {
-	result := errors.ManifestResult{Name: bundle.Name}
+	result := errors.ManifestResult{}
 	if bundle == nil {
 		result.Add(errors.ErrInvalidBundle("Bundle is nil", nil))
 		return result
 	}
+	result.Name = bundle.Name
 
 	if bundle.CSV == nil {
 		result.Add(errors.ErrInvalidBundle("Bundle csv is nil", bundle.Name))

--- a/pkg/validation/internal/operatorhub.go
+++ b/pkg/validation/internal/operatorhub.go
@@ -163,12 +163,13 @@ func validateOperatorHubDeprecated(objs ...interface{}) (results []errors.Manife
 }
 
 func validateBundleOperatorHub(bundle *manifests.Bundle, k8sVersion string) errors.ManifestResult {
-	result := errors.ManifestResult{Name: bundle.Name}
+	result := errors.ManifestResult{}
 
 	if bundle == nil {
 		result.Add(errors.ErrInvalidBundle("Bundle is nil", nil))
 		return result
 	}
+	result.Name = bundle.Name
 
 	if bundle.CSV == nil {
 		result.Add(errors.ErrInvalidBundle("Bundle csv is nil", bundle.Name))

--- a/pkg/validation/internal/operatorhubv2.go
+++ b/pkg/validation/internal/operatorhubv2.go
@@ -33,12 +33,12 @@ func validateOperatorHubV2(objs ...interface{}) (results []errors.ManifestResult
 }
 
 func validateBundleOperatorHubV2(bundle *manifests.Bundle, k8sVersion string) errors.ManifestResult {
-	result := errors.ManifestResult{Name: bundle.Name}
-
+	result := errors.ManifestResult{}
 	if bundle == nil {
 		result.Add(errors.ErrInvalidBundle("Bundle is nil", nil))
 		return result
 	}
+	result.Name = bundle.Name
 
 	if bundle.CSV == nil {
 		result.Add(errors.ErrInvalidBundle("Bundle csv is nil", bundle.Name))


### PR DESCRIPTION
Several of the functions in `pkg/validation/internal` properly check to make sure that they haven't received a nil pointer, but they imporperly do it only after first attempting to dereference the pointer.