### PR TITLE
pkg/manifests: fix dropped walk errors

### DIFF
--- a/pkg/manifests/bundleloader.go
+++ b/pkg/manifests/bundleloader.go
@@ -122,6 +122,9 @@ func collectWalkErrs(walk filepath.WalkFunc, errs *[]error) filepath.WalkFunc {
 }
 
 func (b *bundleLoader) LoadBundleWalkFunc(path string, f os.FileInfo, err error) error {
+	if err != nil {
+		return err
+	}
 	if f == nil {
 		return fmt.Errorf("invalid file: %v", f)
 	}

--- a/pkg/manifests/packagemanifestloader.go
+++ b/pkg/manifests/packagemanifestloader.go
@@ -42,6 +42,9 @@ func (p *packageManifestLoader) LoadPackage() error {
 // LoadPackagesWalkFunc attempts to unmarshal the file at the given path into a PackageManifest resource.
 // If unmarshaling is successful, the PackageManifest is added to the loader's store.
 func (p *packageManifestLoader) LoadPackagesWalkFunc(path string, f os.FileInfo, err error) error {
+	if err != nil {
+		return err
+	}
 	if f == nil {
 		return fmt.Errorf("invalid file: %v", f)
 	}
@@ -85,6 +88,9 @@ func (p *packageManifestLoader) LoadPackagesWalkFunc(path string, f os.FileInfo,
 }
 
 func (p *packageManifestLoader) LoadBundleWalkFunc(path string, f os.FileInfo, err error) error {
+	if err != nil {
+		return err
+	}
 	if f == nil {
 		return fmt.Errorf("invalid file: %v", f)
 	}

--- a/pkg/manifests/walkfunc_test.go
+++ b/pkg/manifests/walkfunc_test.go
@@ -1,0 +1,100 @@
+package manifests
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBundleLoaderLoadBundleWalkFunc_PropagatesWalkError(t *testing.T) {
+	loader := NewBundleLoader(t.TempDir())
+	walkErr := errors.New("permission denied")
+
+	err := loader.LoadBundleWalkFunc("some/path", nil, walkErr)
+	require.ErrorIs(t, err, walkErr)
+}
+
+func TestPackageManifestLoaderLoadPackagesWalkFunc_PropagatesWalkError(t *testing.T) {
+	loader := NewPackageManifestLoader(t.TempDir())
+	walkErr := errors.New("permission denied")
+
+	err := loader.LoadPackagesWalkFunc("some/path", nil, walkErr)
+	require.ErrorIs(t, err, walkErr)
+}
+
+func TestPackageManifestLoaderLoadBundleWalkFunc_PropagatesWalkError(t *testing.T) {
+	loader := NewPackageManifestLoader(t.TempDir())
+	walkErr := errors.New("permission denied")
+
+	err := loader.LoadBundleWalkFunc("some/path", nil, walkErr)
+	require.ErrorIs(t, err, walkErr)
+}
+
+func TestCollectWalkErrs_CollectsWalkErrors(t *testing.T) {
+	walkErr := errors.New("stat failed")
+	loader := NewBundleLoader(t.TempDir())
+
+	var errs []error
+	wrapped := collectWalkErrs(loader.LoadBundleWalkFunc, &errs)
+
+	// Calling with a non-nil walk error should collect it and not panic.
+	err := wrapped("some/path", nil, walkErr)
+	require.NoError(t, err, "collectWalkErrs should swallow non-SkipDir errors so Walk continues")
+	require.Len(t, errs, 1)
+	require.ErrorIs(t, errs[0], walkErr)
+}
+
+func TestBundleLoaderLoadBundleWalkFunc_NilFileInfoWithoutError(t *testing.T) {
+	loader := NewBundleLoader(t.TempDir())
+
+	err := loader.LoadBundleWalkFunc("some/path", nil, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid file")
+}
+
+func TestLoadBundle_NonexistentDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nonexistent")
+
+	loader := NewBundleLoader(dir)
+	err := loader.LoadBundle()
+	require.Error(t, err)
+}
+
+func TestLoadPackage_NonexistentDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nonexistent")
+
+	loader := NewPackageManifestLoader(dir)
+	err := loader.LoadPackage()
+	require.Error(t, err)
+}
+
+func TestLoadBundle_InaccessibleSubpath(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("test requires non-root: root bypasses directory permission checks")
+	}
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "subdir")
+	require.NoError(t, os.Mkdir(sub, 0o000))
+	t.Cleanup(func() { os.Chmod(sub, 0o755) })
+
+	loader := NewBundleLoader(dir)
+	err := loader.LoadBundle()
+	require.Error(t, err)
+}
+
+func TestLoadPackage_InaccessibleSubpath(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("test requires non-root: root bypasses directory permission checks")
+	}
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "subdir")
+	require.NoError(t, os.Mkdir(sub, 0o000))
+	t.Cleanup(func() { os.Chmod(sub, 0o755) })
+
+	loader := NewPackageManifestLoader(dir)
+	err := loader.LoadPackage()
+	require.Error(t, err)
+}


### PR DESCRIPTION
A `filepath.Walk()` function takes an error as one of its arguments. Usually the first thing to do in a `Walk()` is to check if the `err` provided is not `nil` and should be returned. This fixes three places in `pkg/manifests` where a `WalkFunc()` was not handling the `err`.

Tests continue to pass.