### PR TITLE
fix: stop emitting false-positive deprecated-API warnings for RBAC rules

### DIFF
--- a/pkg/validation/internal/removed_apis.go
+++ b/pkg/validation/internal/removed_apis.go
@@ -323,7 +323,7 @@ func getRemovedAPIsOn1_25From(bundle *manifests.Bundle) (map[string][]string, ma
 		}
 	}
 
-	// deprecatedGroupResource maps resources that were entirely removed from
+	// removedGroupResource maps resources that were entirely removed from
 	// their API group in v1.25 with no stable replacement in the same group.
 	// RBAC PolicyRules only specify apiGroups and resources (no version), so
 	// we cannot distinguish "batch/v1beta1 CronJob" from "batch/v1 CronJob"
@@ -338,13 +338,13 @@ func getRemovedAPIsOn1_25From(bundle *manifests.Bundle) (map[string][]string, ma
 	//   - node.k8s.io/runtimeclasses -> node.k8s.io/v1 (stable since v1.20)
 	//
 	// See: https://github.com/operator-framework/api/issues/378
-	deprecatedGroupResource := map[schema.GroupResource]struct{}{
+	removedGroupResource := map[schema.GroupResource]struct{}{
 		// PodSecurityPolicy was entirely removed in v1.25 with no in-group replacement.
 		{Group: "policy", Resource: "podsecuritypolicies"}: {},
 	}
 
-	warnIfDeprecated := func(gr schema.GroupResource, msg string) {
-		if _, ok := deprecatedGroupResource[gr]; ok {
+	warnIfRemoved := func(gr schema.GroupResource, msg string) {
+		if _, ok := removedGroupResource[gr]; ok {
 			warnDeprecatedAPIs[gr.Resource] = append(warnDeprecatedAPIs[gr.Resource], msg)
 		}
 	}
@@ -403,7 +403,7 @@ func getRemovedAPIsOn1_25From(bundle *manifests.Bundle) (map[string][]string, ma
 										if _, ok := resInCsvCrds[res]; ok {
 											continue
 										}
-										warnIfDeprecated(schema.GroupResource{Group: apiGroup, Resource: res}, fmt.Sprintf("ClusterServiceVersion.Spec.InstallStrategy.StrategySpec.%s[%d].Rules[%d]", permField, i, j))
+										warnIfRemoved(schema.GroupResource{Group: apiGroup, Resource: res}, fmt.Sprintf("ClusterServiceVersion.Spec.InstallStrategy.StrategySpec.%s[%d].Rules[%d]", permField, i, j))
 									}
 								}
 							}

--- a/pkg/validation/internal/removed_apis.go
+++ b/pkg/validation/internal/removed_apis.go
@@ -323,14 +323,24 @@ func getRemovedAPIsOn1_25From(bundle *manifests.Bundle) (map[string][]string, ma
 		}
 	}
 
+	// deprecatedGroupResource maps resources that were entirely removed from
+	// their API group in v1.25 with no stable replacement in the same group.
+	// RBAC PolicyRules only specify apiGroups and resources (no version), so
+	// we cannot distinguish "batch/v1beta1 CronJob" from "batch/v1 CronJob"
+	// in an RBAC rule. Only flag resources that no longer exist at all.
+	//
+	// Resources removed from this map (they still exist under stable versions):
+	//   - batch/cronjobs            -> batch/v1 (stable since v1.21)
+	//   - discovery.k8s.io/endpointslices -> discovery.k8s.io/v1 (stable since v1.21)
+	//   - events.k8s.io/events      -> events.k8s.io/v1 (stable since v1.19)
+	//   - autoscaling/horizontalpodautoscalers -> autoscaling/v2 (stable since v1.23)
+	//   - policy/poddisruptionbudgets -> policy/v1 (stable since v1.21)
+	//   - node.k8s.io/runtimeclasses -> node.k8s.io/v1 (stable since v1.20)
+	//
+	// See: https://github.com/operator-framework/api/issues/378
 	deprecatedGroupResource := map[schema.GroupResource]struct{}{
-		{Group: "batch", Resource: "cronjobs"}:                       {},
-		{Group: "discovery.k8s.io", Resource: "endpointslices"}:      {},
-		{Group: "events.k8s.io", Resource: "events"}:                 {},
-		{Group: "autoscaling", Resource: "horizontalpodautoscalers"}: {},
-		{Group: "policy", Resource: "poddisruptionbudgets"}:          {},
-		{Group: "policy", Resource: "podsecuritypolicies"}:           {},
-		{Group: "node.k8s.io", Resource: "runtimeclasses"}:           {},
+		// PodSecurityPolicy was entirely removed in v1.25 with no in-group replacement.
+		{Group: "policy", Resource: "podsecuritypolicies"}: {},
 	}
 
 	warnIfDeprecated := func(gr schema.GroupResource, msg string) {

--- a/pkg/validation/internal/removed_apis_test.go
+++ b/pkg/validation/internal/removed_apis_test.go
@@ -71,14 +71,15 @@ func Test_GetRemovedAPIsOn1_25From(t *testing.T) {
 	mock["HorizontalPodAutoscaler"] = []string{"memcached-operator-hpa"}
 	mock["PodDisruptionBudget"] = []string{"memcached-operator-policy-manager"}
 
+	// Only PodSecurityPolicy should produce an RBAC warning because it was
+	// entirely removed in v1.25 with no stable replacement in the same API
+	// group. The other resources (cronjobs, endpointslices, events,
+	// horizontalpodautoscalers, poddisruptionbudgets, runtimeclasses) still
+	// exist under stable versions in their respective groups, so RBAC rules
+	// referencing them are not deprecated.
+	// See: https://github.com/operator-framework/api/issues/378
 	warnMock := make(map[string][]string)
-	warnMock["cronjobs"] = []string{"ClusterServiceVersion.Spec.InstallStrategy.StrategySpec.ClusterPermissions[0].Rules[7]"}
-	warnMock["endpointslices"] = []string{"ClusterServiceVersion.Spec.InstallStrategy.StrategySpec.Permissions[0].Rules[3]"}
-	warnMock["events"] = []string{"ClusterServiceVersion.Spec.InstallStrategy.StrategySpec.Permissions[0].Rules[2]"}
-	warnMock["horizontalpodautoscalers"] = []string{"ClusterServiceVersion.Spec.InstallStrategy.StrategySpec.Permissions[0].Rules[4]"}
-	warnMock["poddisruptionbudgets"] = []string{"ClusterServiceVersion.Spec.InstallStrategy.StrategySpec.Permissions[0].Rules[5]"}
 	warnMock["podsecuritypolicies"] = []string{"ClusterServiceVersion.Spec.InstallStrategy.StrategySpec.Permissions[0].Rules[5]"}
-	warnMock["runtimeclasses"] = []string{"ClusterServiceVersion.Spec.InstallStrategy.StrategySpec.Permissions[0].Rules[6]"}
 
 	type args struct {
 		bundleDir string


### PR DESCRIPTION
## Problem

The `deprecatedGroupResource` map in `getRemovedAPIsOn1_25From()` flags RBAC PolicyRules that reference API groups where a beta version was removed in Kubernetes v1.25. However, RBAC `PolicyRule` objects only specify `apiGroups` and `resources`, they do not carry a `version` field. This means the validator cannot distinguish between a rule granting access to `batch/v1 CronJob` (stable) and `batch/v1beta1 CronJob` (removed).

This produces false-positive warnings for every operator that has RBAC rules for common resources like CronJobs, HPAs, Events, PDBs, EndpointSlices, or RuntimeClasses, even when the operator exclusively uses stable API versions.

**Impact:** This warning appears on the community-operators-prod CI pipeline for every operator that needs RBAC access to these resources (see [community-operators-prod#9875](https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/9875) for an example). As noted in the original issue, the misleading warning [has led developers to incorrectly modify their RBAC rules](https://github.com/grafana/loki/pull/15107#issuecomment-2503499461).

## Fix

Remove entries from `deprecatedGroupResource` where the resource still exists under a stable API version in the same group:

| Removed Entry | Stable Version |
|---|---|
| `batch/cronjobs` | `batch/v1` (stable since v1.21) |
| `discovery.k8s.io/endpointslices` | `discovery.k8s.io/v1` (stable since v1.21) |
| `events.k8s.io/events` | `events.k8s.io/v1` (stable since v1.19) |
| `autoscaling/horizontalpodautoscalers` | `autoscaling/v2` (stable since v1.23) |
| `policy/poddisruptionbudgets` | `policy/v1` (stable since v1.21) |
| `node.k8s.io/runtimeclasses` | `node.k8s.io/v1` (stable since v1.20) |

Keep `policy/podsecuritypolicies` since PodSecurityPolicy was entirely removed in v1.25 with no stable replacement in the same API group.

The `deprecatedGvk` check (for actual versioned manifests in the bundle) is unaffected and continues to correctly flag deprecated objects like `autoscaling/v2beta1 HorizontalPodAutoscaler` or `policy/v1beta1 PodDisruptionBudget` when they appear as bundle manifests.

## Testing

- Updated `Test_GetRemovedAPIsOn1_25From` to expect warnings only for `podsecuritypolicies`
- Full test suite passes: `go test ./...`

Fixes #378